### PR TITLE
Add content validation schema and CI workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate W3OS Content
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate guides & requirements
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run content validator
+        run: node scripts/validate.js

--- a/guides/account configurations/individuals/devops-accounts/vercel.md
+++ b/guides/account configurations/individuals/devops-accounts/vercel.md
@@ -5,7 +5,7 @@ scope: INDIVIDUAL
 -->
 
 <div align="center">
-  <img src="../../../../images/guides/vercel.svg" alt="Vercel Logo" width="64" height="64"> <h2><a href="https://vercel.com/" target="_blank">Vercel</a> Account Settings</h2>
+  <img src="../../../../images/guides/vercel.svg" alt="Vercel Logo" width="64" height="64"> <h2><a href="https://vercel.com/" target="_blank">Vercel</a> Configuration Guide</h2>
 </div>
 
 ## Individual Account Settings

--- a/guides/account configurations/organizations/devops-accounts/vercel.md
+++ b/guides/account configurations/organizations/devops-accounts/vercel.md
@@ -5,7 +5,7 @@ scope: ORGANIZATION
 -->
 
 <div align="center">
-  <img src="../../../../images/guides/vercel.svg" alt="Vercel Logo" width="64" height="64"> <h2><a href="https://vercel.com/" target="_blank">Vercel</a> Account Settings</h2>
+  <img src="../../../../images/guides/vercel.svg" alt="Vercel Logo" width="64" height="64"> <h2><a href="https://vercel.com/" target="_blank">Vercel</a> Configuration Guide</h2>
 </div>
 
 ## Team Settings

--- a/guides/dns-security.md
+++ b/guides/dns-security.md
@@ -1,8 +1,8 @@
----
+<!--
 id: dns-security-records-guide
 type: GUIDE
 scope: ORGANIZATION
----
+-->
 
 <div align="center">
   <h1>DNS Security Records Guide</h1>

--- a/schema/w3os-content.schema.json
+++ b/schema/w3os-content.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/W3OSC/web3-opsec-standard/main/schema/w3os-content.schema.json",
+  "title": "W3OS Content",
+  "description": "Full shape of the data the Sentry sync engine reads from this repository. Use this schema to understand what each markdown file must produce, and to validate a generated manifest before merge.",
+  "type": "object",
+  "required": ["domains", "guides"],
+  "additionalProperties": false,
+  "properties": {
+    "domains": {
+      "type": "array",
+      "description": "Security domains. Each domain maps to a requirements markdown file at requirements/{id}-{slug}.md",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/domain" }
+    },
+    "guides": {
+      "type": "array",
+      "description": "All guide markdown files found under guides/. Each file must contain a valid HTML comment metadata block.",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/guide" }
+    }
+  },
+
+  "$defs": {
+    "domain": {
+      "type": "object",
+      "required": ["id", "name", "slug", "order", "requirements"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^0[1-9]|[1-9][0-9]$",
+          "description": "Two-digit numeric domain ID matching the filename prefix (e.g. '01').",
+          "examples": ["01", "02", "03", "04", "05"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable domain name.",
+          "examples": ["Wallet & Multi-Sig Management", "Endpoint Security"]
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+          "description": "URL-safe slug. Combined with id to form the requirements filename: {id}-{slug}.md",
+          "examples": ["wallet-multisig", "endpoints", "communications-socials"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional short description of the domain."
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Display order (1-based)."
+        },
+        "requirements": {
+          "type": "array",
+          "description": "Security requirements parsed from requirements/{id}-{slug}.md",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/requirement" }
+        }
+      }
+    },
+
+    "requirement": {
+      "type": "object",
+      "required": ["requirementId", "title", "section", "controlPoints", "order"],
+      "additionalProperties": false,
+      "properties": {
+        "requirementId": {
+          "type": "string",
+          "pattern": "^SP-[A-Z]+-\\d{3}$",
+          "description": "Requirement identifier. Format: SP-{DOMAIN_CODE}-{NNN}. Must be unique within a domain.",
+          "examples": ["SP-WM-001", "SP-EP-012"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short title of the requirement, parsed from **SP-XX-NNN: Title** in the markdown."
+        },
+        "section": {
+          "type": "string",
+          "description": "Section heading under which this requirement falls (### **Section Name** in markdown). May be empty string for requirements before any section header."
+        },
+        "controlPoints": {
+          "type": "array",
+          "description": "Bullet-point control points that define compliance for this requirement. Parsed from `- ` lines following the requirement header.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based position of this requirement within its domain file."
+        }
+      }
+    },
+
+    "guide": {
+      "type": "object",
+      "required": ["w3osId", "type", "title", "description", "category", "scope", "checklistItems"],
+      "additionalProperties": false,
+      "properties": {
+        "w3osId": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+          "description": "Unique guide identifier sourced from the `id` field in the guide's HTML comment metadata block."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["CONFIGURATION", "GUIDE"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Extracted from the first <h1>, <h2> Configuration Guide heading, or # heading in the file."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description. Auto-derived for CONFIGURATION guides; extracted from the Overview section for GUIDE type."
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Derived from folder path under guides/. Examples: 'Business Tools', 'Communication Platforms', 'DevOps Accounts', 'General Security'."
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["INDIVIDUAL", "ORGANIZATION"]
+        },
+        "checklistItems": {
+          "type": "array",
+          "description": "All `- [ ]` checklist items parsed from the guide. At least one is required for the sync to accept the guide.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * W3OS content validator.
+ * Validates guide markdown files against schema/guide-metadata.schema.json
+ * and requirement markdown files for correct SP-XX-NNN formatting.
+ * Reports all errors and exits non-zero if any are found.
+ *
+ * Usage: node scripts/validate.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const GUIDES_DIR = path.join(ROOT, 'guides');
+const REQUIREMENTS_DIR = path.join(ROOT, 'requirements');
+
+const VALID_TYPES = ['CONFIGURATION', 'GUIDE'];
+const VALID_SCOPES = ['INDIVIDUAL', 'ORGANIZATION'];
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+const REQUIREMENT_ID_PATTERN = /^SP-[A-Z]+-\d{3}$/;
+
+let errors = [];
+let warnings = [];
+
+function error(file, msg) {
+  errors.push(`  [ERROR] ${file}: ${msg}`);
+}
+
+function warn(file, msg) {
+  warnings.push(`  [WARN]  ${file}: ${msg}`);
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function getAllFiles(dir, ext = '.md') {
+  if (!fs.existsSync(dir)) return [];
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...getAllFiles(full, ext));
+    else if (entry.isFile() && entry.name.endsWith(ext)) results.push(full);
+  }
+  return results;
+}
+
+function parseHtmlCommentMetadata(content) {
+  const result = {};
+  const pattern = /<!--\s*([\s\S]*?)\s*-->/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    const commentContent = match[1];
+    const lines = commentContent.includes('\n')
+      ? commentContent.split('\n')
+      : [commentContent];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx === -1) continue;
+      const key = trimmed.substring(0, colonIdx).trim();
+      let value = trimmed.substring(colonIdx + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!result[key]) result[key] = value;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function countChecklistItems(content) {
+  return (content.match(/^[ \t]*- \[ \]/gm) || []).length;
+}
+
+// ── Guide validation ───────────────────────────────────────────────────────
+
+function validateGuides() {
+  console.log('\nValidating guides...');
+  const files = getAllFiles(GUIDES_DIR);
+  const seenIds = new Map(); // id → first file
+
+  for (const file of files) {
+    const rel = path.relative(ROOT, file);
+    const content = fs.readFileSync(file, 'utf8');
+    const meta = parseHtmlCommentMetadata(content);
+
+    if (!meta) {
+      error(rel, 'missing HTML comment metadata block (id, type, scope required)');
+      continue;
+    }
+
+    // id
+    if (!meta.id) {
+      error(rel, 'metadata missing required field: id');
+    } else if (!ID_PATTERN.test(meta.id)) {
+      error(rel, `id "${meta.id}" must be kebab-case (lowercase letters, digits, hyphens only)`);
+    } else if (seenIds.has(meta.id)) {
+      error(rel, `duplicate id "${meta.id}" - already used by ${seenIds.get(meta.id)}`);
+    } else {
+      seenIds.set(meta.id, rel);
+    }
+
+    // type
+    if (!meta.type) {
+      error(rel, 'metadata missing required field: type');
+    } else if (!VALID_TYPES.includes(meta.type)) {
+      error(rel, `type "${meta.type}" is invalid. Must be one of: ${VALID_TYPES.join(', ')}`);
+    }
+
+    // scope
+    if (!meta.scope) {
+      error(rel, 'metadata missing required field: scope');
+    } else if (!VALID_SCOPES.includes(meta.scope)) {
+      error(rel, `scope "${meta.scope}" is invalid. Must be one of: ${VALID_SCOPES.join(', ')}`);
+    }
+
+    // checklist items
+    const checklistCount = countChecklistItems(content);
+    if (checklistCount === 0) {
+      error(rel, 'no checklist items found (- [ ] ...) - sync will skip this guide');
+    }
+
+    // title presence
+    const hasTitle =
+      /<h1[^>]*>[^<]+<\/h1>/.test(content) ||
+      /<h2[^>]*>.*?Configuration Guide<\/h2>/.test(content) ||
+      /^# .+/m.test(content);
+    if (!hasTitle) {
+      warn(rel, 'no title found (<h1>, <h2> Configuration Guide, or # heading)');
+    }
+  }
+
+  console.log(`  Scanned ${files.length} guide file(s). Found ${seenIds.size} unique IDs.`);
+}
+
+// ── Requirements validation ────────────────────────────────────────────────
+
+function validateRequirements() {
+  console.log('\nValidating requirements...');
+  const files = getAllFiles(REQUIREMENTS_DIR);
+  const DOMAIN_FILE_PATTERN = /^\d{2}-[a-z0-9-]+\.md$/;
+
+  for (const file of files) {
+    const rel = path.relative(ROOT, file);
+    const filename = path.basename(file);
+
+    if (!DOMAIN_FILE_PATTERN.test(filename)) {
+      warn(rel, `filename does not match expected pattern NN-slug.md`);
+    }
+
+    const content = fs.readFileSync(file, 'utf8');
+    const seenReqIds = new Set();
+    let reqCount = 0;
+
+    for (const match of content.matchAll(/^\*\*(SP-[A-Z]+-\d+): ([^*]+)\*\*/gm)) {
+      const reqId = match[1];
+      reqCount++;
+
+      if (!REQUIREMENT_ID_PATTERN.test(reqId)) {
+        error(rel, `requirement ID "${reqId}" does not match SP-XX-NNN pattern`);
+      }
+      if (seenReqIds.has(reqId)) {
+        error(rel, `duplicate requirement ID "${reqId}"`);
+      }
+      seenReqIds.add(reqId);
+    }
+
+    if (reqCount === 0) {
+      warn(rel, 'no requirements found (**SP-XX-NNN: ...**) - file may be empty or malformed');
+    } else {
+      console.log(`  ${filename}: ${reqCount} requirement(s)`);
+    }
+
+    // Check each requirement has at least one bullet point following it
+    const lines = content.split('\n');
+    let inReq = false;
+    let bulletCount = 0;
+    let lastReqId = '';
+    for (const line of lines) {
+      const trimmed = line.trim();
+      const reqMatch = trimmed.match(/^\*\*(SP-[A-Z]+-\d+): [^*]+\*\*/);
+      if (reqMatch) {
+        if (inReq && bulletCount === 0) {
+          error(rel, `requirement "${lastReqId}" has no control points (bullet points)`);
+        }
+        lastReqId = reqMatch[1];
+        bulletCount = 0;
+        inReq = true;
+        continue;
+      }
+      if (inReq && trimmed.startsWith('- ')) {
+        bulletCount++;
+        continue;
+      }
+      if (inReq && (trimmed === '' || trimmed.startsWith('#'))) {
+        if (bulletCount === 0) {
+          error(rel, `requirement "${lastReqId}" has no control points (bullet points)`);
+        }
+        inReq = false;
+      }
+    }
+    if (inReq && bulletCount === 0) {
+      error(rel, `requirement "${lastReqId}" has no control points (bullet points)`);
+    }
+  }
+
+  console.log(`  Scanned ${files.length} requirement file(s).`);
+}
+
+// ── Run ────────────────────────────────────────────────────────────────────
+
+validateGuides();
+validateRequirements();
+
+console.log('');
+if (warnings.length > 0) {
+  console.log(`Warnings (${warnings.length}):`);
+  warnings.forEach(w => console.log(w));
+  console.log('');
+}
+
+if (errors.length > 0) {
+  console.error(`Validation FAILED - ${errors.length} error(s):`);
+  errors.forEach(e => console.error(e));
+  process.exit(1);
+} else {
+  console.log(`Validation PASSED - no errors found.`);
+}


### PR DESCRIPTION
## What

- `schema/w3os-content.schema.json` - documents the full shape sentry ingests from this repo (domains, requirements, guides)
- `scripts/validate.js` - zero-dependency validator: checks guide metadata blocks, unique IDs, checklist presence, requirement formatting
- `.github/workflows/validate.yml` - runs validator on every push/PR to main

## Fixes

- `guides/.../vercel.md` (individual + org): heading said "Account Settings" instead of "Configuration Guide" - inconsistent with all other guides and caused title extraction fallback

## Why

Prevents broken/missing content from reaching sentry sync. No changes to sync process required.