### PR TITLE
Add OpenClaw and Hermes security configuration guides

### DIFF
--- a/guides/account configurations/individuals/business-tools/hermes.md
+++ b/guides/account configurations/individuals/business-tools/hermes.md
@@ -1,0 +1,74 @@
+<!--
+id: hermes-individual-configuration
+type: CONFIGURATION
+scope: INDIVIDUAL
+-->
+
+<div align="center"> <h2><a href="https://hermes-agent.nousresearch.com" target="_blank" rel="noopener noreferrer">Hermes</a> Configuration Guide</h2> </div>
+
+> Hermes is an autonomous AI agent by NousResearch with file-system, shell, and MCP access. Its built-in security model has seven layers - user authorization, dangerous command approval, container isolation, MCP credential filtering, context file scanning, cross-session isolation, and input sanitization. The checklist below ensures those layers are correctly configured. Reference: [Hermes Security Docs](https://hermes-agent.nousresearch.com/docs/user-guide/security).
+
+---
+
+## Dangerous Command Approval (`~/.hermes/config.yaml`)
+
+- [ ] Set `approvals.mode: manual` - never use `smart` (auto-approve) or `off` (YOLO) in production environments
+- [ ] Keep `cron_mode: deny` (default) - headless cron jobs should be blocked from auto-approving dangerous commands
+- [ ] Keep `mcp_reload_confirm: true` - require confirmation before rebuilding the MCP tool set
+- [ ] Keep `destructive_slash_confirm: true` - require confirmation before destructive session commands (`/clear`, `/reset`, `/undo`)
+- [ ] Set a reasonable `timeout` (default 60 s) - on timeout the command is **denied** by default; do not extend it unnecessarily
+
+---
+
+## YOLO Mode - Keep Off
+
+- [ ] **Never** start sessions with `hermes --yolo` or `hermes chat --yolo` on machines with real data or credentials
+- [ ] Do not set `HERMES_YOLO_MODE=1` in any persistent shell profile or `.env` file
+- [ ] Treat any session where `/yolo` was toggled on as untrusted - restart a clean session before performing sensitive operations
+
+---
+
+## Permanent Allowlist Review (`~/.hermes/config.yaml`)
+
+- [ ] Audit `command_allowlist` entries regularly - entries added via "always approve" bypass future approval prompts permanently
+- [ ] Remove any allowlist entries that are no longer required
+- [ ] Use `hermes config edit` to review the allowlist before sharing a machine or transferring ownership
+
+---
+
+## Container Isolation
+
+- [ ] Run Hermes inside a **Docker, Singularity, or Modal** container for any task involving untrusted code, files, or MCP servers
+- [ ] Verify the container backend is active - dangerous-command checks are relaxed inside containers because the container is the security boundary; confirm your container is actually sandboxed
+- [ ] Do not mount host sensitive directories (e.g. `~/.ssh`, `~/.hermes`) into agent containers
+
+---
+
+## MCP Credential Filtering
+
+- [ ] Confirm that MCP subprocesses receive only the environment variables they need - Hermes filters credentials by default, but verify no `_ALL_ENVS` override is set
+- [ ] Never store production private keys or mnemonics in `~/.hermes/.env` - use a secrets manager and inject only at runtime
+
+---
+
+## Context File Scanning (Prompt Injection)
+
+- [ ] Ensure context file scanning is enabled (default) - this detects prompt injection attempts in project files before they reach the model
+- [ ] Treat any project file from an untrusted source as potentially malicious; review scan warnings before proceeding
+
+---
+
+## User Authorization (Gateway)
+
+- [ ] Configure explicit **platform allowlists** in `~/.hermes/.env` (e.g. `TELEGRAM_ALLOWED_USERS`, `DISCORD_ALLOWED_USERS`) - do not rely on `GATEWAY_ALLOW_ALL_USERS=true` outside of private, single-user deployments
+- [ ] Prefer **DM pairing** over open allowlists when deploying the gateway for a team - approve pairing codes via `hermes pairing approve <platform> <code>`
+- [ ] Periodically audit approved users with `hermes pairing list` and revoke stale entries with `hermes pairing revoke`
+- [ ] Set `unauthorized_dm_behavior: ignore` on high-noise platforms (e.g. email, WhatsApp) to suppress unsolicited pairing requests
+
+---
+
+## Credentials & Secrets
+
+- [ ] Keep `~/.hermes/.env` permissions at `0600` - Hermes enforces this but verify after any manual edits
+- [ ] Do not commit `~/.hermes/config.yaml` or `~/.hermes/.env` to version control
+- [ ] Rotate any API keys or tokens that were ever stored in plain text in the Hermes config directory

--- a/guides/account configurations/individuals/business-tools/openclaw.md
+++ b/guides/account configurations/individuals/business-tools/openclaw.md
@@ -1,0 +1,72 @@
+<!--
+id: openclaw-individual-configuration
+type: CONFIGURATION
+scope: INDIVIDUAL
+-->
+
+<div align="center"> <h2><a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a> Configuration Guide</h2> </div>
+
+> OpenClaw is a high-privilege autonomous AI agent that runs with terminal/root-level access and continuously installs Skills, MCPs, scripts, and tools. This expansive capability surface creates serious risks - prompt injection, supply chain poisoning, destructive operations, and business-logic abuse. The checklist below is derived from the [SlowMist OpenClaw Security Practice Guide](https://github.com/slowmist/openclaw-security-practice-guide).
+
+---
+
+## Model Selection
+
+- [ ] Use a **strong, latest-generation reasoning model** (e.g. Gemini, Claude Opus, Kimi, MiniMax families) - weaker models misclassify red-line commands, defeating all behavioral controls
+
+---
+
+## Deploy the Security Guide to OpenClaw
+
+- [ ] Download the latest guide from the [SlowMist repo](https://github.com/slowmist/openclaw-security-practice-guide) (use **v2.8 Beta** for OpenClaw ≥ 2026.4, **v2.7** for older versions)
+- [ ] Drop the guide markdown file directly into chat and ask OpenClaw to evaluate it for conflicts with the current setup before deploying
+- [ ] Issue the deployment command and confirm the agent reports a successful defense-matrix deployment
+- [ ] Optionally run the [Red Teaming / Validation Guide](https://github.com/slowmist/openclaw-security-practice-guide/blob/main/docs/Validation-Guide-en.md) to verify the agent correctly blocks red-line operations
+
+---
+
+## Behavioral Blacklists (Red & Yellow Lines)
+
+- [ ] Confirm red-line rules are active - the agent must **halt and require explicit human approval** for any irreversible or destructive operation (e.g. `rm -rf`, mass-delete, credential export)
+- [ ] Confirm yellow-line rules are active - high-risk but potentially legitimate actions (e.g. permission changes, service restarts) must be flagged before execution
+- [ ] Test that the agent refuses to bypass its own red-line rules even when instructed to in a new chat message
+
+---
+
+## Anti-Supply Chain Poisoning (Skill / MCP Installation)
+
+- [ ] Enable the **Skill/MCP installation audit protocol** - every new Skill, MCP, or script must be reviewed for suspicious instructions, network callbacks, or credential access before installation
+- [ ] Require OpenClaw to perform a **secondary download detection** check (looking for any unexpected file fetches embedded in Skill logic)
+- [ ] Restrict Skill sources to known, trusted registries; reject unsigned or unverifiable packages
+
+---
+
+## Permission Narrowing
+
+- [ ] Run OpenClaw in the **least-privilege environment** that supports your workflow - avoid persistent root sessions
+- [ ] Enable **Cross-Skill pre-flight checks** so OpenClaw validates that a requested action does not exceed its current permission scope before executing
+- [ ] Disable any capabilities (filesystem write, network egress, etc.) that are not required for the active task
+
+---
+
+## Nightly Automated Audit (Cron Job)
+
+- [ ] Deploy the nightly audit cron job as described in the guide - it should cover **all 13 core metrics** and produce **explicit output for healthy states** (not just failures)
+- [ ] Configure the `--light-context` flag for the audit cron to prevent workspace context from hijacking the isolated audit session
+- [ ] Set report output path to `$OC/security-reports/` (not `/tmp`) with 30-day rotation so reports survive reboots
+- [ ] Schedule a regular review of the audit reports
+
+---
+
+## Disaster Recovery
+
+- [ ] Enable **Brain Git backup** so OpenClaw's configuration and memory can be restored after an incident
+- [ ] Test restoration from backup at least once to confirm it works
+- [ ] Store backup credentials separately from the machine OpenClaw runs on
+
+---
+
+## Post-Upgrade Maintenance
+
+- [ ] After any OpenClaw engine upgrade, **rebuild hash baselines** following the post-upgrade workflow in the guide before resuming autonomous operation
+- [ ] Re-run validation drills after each upgrade to confirm defenses remain intact


### PR DESCRIPTION
Adds individual security configuration guides for OpenClaw and Hermes AI agents under `guides/account configurations/individuals/business-tools/`.