### PR TITLE
Add AI agent operational security domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,7 +770,9 @@
                     { id: '02', name: 'Endpoint Security', slug: 'endpoints' },
                     { id: '03', name: 'Communications & Social Media', slug: 'communications-socials' },
                     { id: '04', name: 'DevOps & Infrastructure', slug: 'devops-infrastructure' },
-                    { id: '05', name: 'General Security', slug: 'general-security' }
+                    { id: '05', name: 'General Security', slug: 'general-security' },
+                    { id: '06', name: 'Financial Controls', slug: 'financial-controls' },
+                    { id: '07', name: 'AI Agent Operational Security', slug: 'ai-agent-opsec' }
                 ];
             }
 

--- a/requirements/07-ai-agent-opsec.md
+++ b/requirements/07-ai-agent-opsec.md
@@ -1,0 +1,61 @@
+# Domain 7: AI Agent Operational Security
+
+## Risks
+
+- R-AI-001: Unapproved Agent Tooling on Organization Devices
+- R-AI-002: Unvetted Agent Extensions and MCP Servers
+- R-AI-003: Prompt Injection via Untrusted Content
+- R-AI-004: Shared Trust Boundary Between Ingestion and Privileged Access
+- R-AI-005: Credential Disclosure to Third-Party Model Providers
+- R-AI-006: Unscoped Credential Availability Within Agent Sessions
+- R-AI-007: Indirect Production Access via Pipeline Modification
+- R-AI-008: Unsupported Isolation Leading to Developer Workarounds
+
+### **Agent Control**
+
+**SP-AI-001: Approved Agent Tooling**
+- The organization must maintain a list of agent tooling approved for use on organization devices
+- Approved tooling must be enforced through the application control capability of the endpoint management or EDR deployment required by SP-EP-006, not through published expectation alone
+- Introduction paths outside application control must be identified, including transient package execution, browser-based agents, and IDE-integrated agents
+- Reducing the number of agents in use is the objective, as every other requirement in this domain applies only to tooling the organization configures
+
+**SP-AI-002: Agent Extension Vetting**
+- Extensions to approved agents, including MCP servers, skills, and plugins, must be vetted before use
+- Vetted extensions must be distributed centrally, consistent with the browser extension controls in SP-EP-011
+- User-installed agent extensions must be prohibited on organization devices
+- Extension configuration files must be included in the sandbox baseline required by SP-AI-007 rather than maintained per-developer
+
+### **Session Isolation**
+
+**SP-AI-003: Agent Session Profiles**
+- A general profile must be defined for agent work that reads untrusted content, including repository files, issues, pull request comments, dependency metadata, and web pages
+- A credentialed profile must be defined for agent work touching production or privileged systems, without general outbound network read access
+- Both profiles must exist as version-controlled configuration shared across the organization, not as per-developer setup
+- Outbound domain allow-listing must not be recorded as satisfying this requirement, as untrusted content is hosted on allowed domains
+- This requirement extends the device separation principle of SP-EP-001 to sessions within a single device
+
+**SP-AI-004: Agent Credential Handling**
+- Credentials must be supplied to agent processes by a secret manager at process start
+- Credentials must not be stored in shell profiles, environment files on disk, or pasted into agent chat interfaces
+- Credentials issued for agent use must be short-lived where the provider supports expiry
+- Where expiry is unsupported, credentials must be scoped to the narrowest permission set the provider allows
+- Client-side blocking of credential paste should be enabled where the approved agent tooling supports it
+
+### **Production Reachability**
+
+**SP-AI-005: Pipeline Configuration Approval**
+- Modification of pipeline definitions, workflow files, and identity trust policies must require human approval through code ownership rules
+- Branch protection must prevent agent-authored pipeline changes from executing with production credentials before approval
+- Repository write access must be treated as production access wherever pipelines execute with production credentials
+
+**SP-AI-006: Agent Production Reachability**
+- Every path from an agent identity to a production resource must be enumerated, including repository write, pipeline execution, identity federation, and role chaining
+- Paths not intended by the organization must be removed
+- Restrictions on direct production access must not be recorded as mitigating where an indirect path remains open
+
+### **Enablement**
+
+**SP-AI-007: Published Sandbox Baseline**
+- The organization must publish a reference sandbox configuration implementing SP-AI-002, SP-AI-003, and SP-AI-004
+- The baseline must be audited before publication and on material change
+- The baseline must be version-controlled and shared, so that developers are not required to construct isolation configurations independently


### PR DESCRIPTION
Adds domain 07 covering operational security for AI coding agents.

## Scope

Seven requirements across four sections:

| Section | Requirements |
|---|---|
| Agent Control | SP-AI-001 approved tooling, SP-AI-002 extension and MCP vetting |
| Session Isolation | SP-AI-003 session profiles, SP-AI-004 credential handling |
| Production Reachability | SP-AI-005 pipeline approval, SP-AI-006 reachability enumeration |
| Enablement | SP-AI-007 published sandbox baseline |

## Design notes

**Cross-references rather than duplicates.** Application control leans on the existing EDR requirement (SP-EP-006) instead of restating it. Extension vetting is framed as the MCP-surface equivalent of the browser extension prohibition in SP-EP-011. Session profiles cite SP-EP-001 as the device-level precedent.

**Two anti-patterns are stated explicitly**, because both are common responses that do not hold:
- Outbound domain allow-listing does not satisfy session isolation, since untrusted content is hosted on allowed domains.
- Restricting direct production access does not mitigate where an indirect path through pipeline execution remains open.

**Scoped to what a small team can actually enforce.** Every requirement is either version-controlled configuration or a one-time enumeration with an inspectable output. Deliberately excluded: review cadences, manually maintained registers, and accepted-risk logs, all of which decay silently. Also excluded as impractical at this scale: taint-propagating agent runtimes, schema-constrained boundary crossing, and endpoint HTTP interception.

## Also included

Registers domains 06 and 07 in the `index.html` checklist tracker. The domain array was still capped at 05, so Financial Controls has never rendered despite the requirements file existing.

## Validation

`node scripts/validate.js` passes, 7 requirements parsed. Verified the tracker renders both new sections locally.