### PR TITLE
Correct domain 06 name to match its file heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,7 +771,7 @@
                     { id: '03', name: 'Communications & Social Media', slug: 'communications-socials' },
                     { id: '04', name: 'DevOps & Infrastructure', slug: 'devops-infrastructure' },
                     { id: '05', name: 'General Security', slug: 'general-security' },
-                    { id: '06', name: 'Financial Controls', slug: 'financial-controls' },
+                    { id: '06', name: 'Financial Controls & Banking Security', slug: 'financial-controls' },
                     { id: '07', name: 'AI Agent Operational Security', slug: 'ai-agent-opsec' }
                 ];
             }


### PR DESCRIPTION
The checklist tracker listed domain 06 as "Financial Controls" while `requirements/06-financial-controls.md` is titled "Financial Controls & Banking Security".

Every other domain's `name` matches its file's H1 exactly, so this restores the convention. Display-only change.

Verified all seven domain names now match their source headings.