### PR TITLE
Tighten Cloud Platforms guides: consistent framing and title fixes

### DIFF
--- a/guides/account configurations/organizations/cloud-platforms/aks.md
+++ b/guides/account configurations/organizations/cloud-platforms/aks.md
@@ -18,10 +18,11 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Control Plane Access
 
+**Attack path:** a public API server exposes the cluster to unauthenticated reach and brute force.
+
 - [ ] Deploy a **[private cluster](https://learn.microsoft.com/en-us/azure/aks/private-clusters)** or use **API Server VNet Integration** — keep the control plane off the internet
 - [ ] If public, restrict to **authorized IP ranges**; never `0.0.0.0/0`
-- [ ] Stay within **supported Kubernetes versions** (N, N-1, N-2) and enable **auto-upgrade**
-- [ ] Enable **node image auto-upgrade** (weekly or automatic)
+- [ ] Stay on a **supported Kubernetes version** (N, N-1, N-2) with **cluster and node-image auto-upgrade** enabled
 
 ---
 
@@ -38,6 +39,8 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Workload Identity
+
+**Attack path:** a broadly-scoped kubelet or workload identity turns a pod compromise into subscription access.
 
 - [ ] Use **[Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)** so pods get federated, scoped tokens
 - [ ] **Do not grant the kubelet identity broad subscription roles** — every pod on the node can reach it
@@ -57,6 +60,8 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Network Segmentation
 
+**Attack path:** a compromised pod reaches every service and node in the VNet.
+
 - [ ] Enable **network policy** (Azure NPM, Calico, or Cilium) with **default-deny ingress and egress**
 - [ ] Use **internal ingress controllers** / internal load balancers; do not expose services publicly by default
 - [ ] Restrict **egress** through **Azure Firewall** or an NVA; allow-list required destinations
@@ -67,6 +72,8 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Workload Privileges
 
+**Attack path:** a privileged or host-namespaced pod escapes to the node and its managed identity.
+
 - [ ] Enforce **Pod Security Admission `restricted`** and back it with **Azure Policy for AKS**
 - [ ] Block **privileged**, hostPath, hostNetwork, hostPID; run **non-root**, drop capabilities, `seccompProfile: RuntimeDefault`
 - [ ] Use **Azure Linux** (or a hardened image) with **ephemeral OS disks**
@@ -76,6 +83,8 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Secrets
 
+**Attack path:** a read Secret or leaked token grants standing access to Azure resources.
+
 - [ ] Store secrets in **Azure Key Vault**; inject via the **[Secrets Store CSI driver](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver)**
 - [ ] Restrict Key Vault access with **RBAC + private endpoint**; enable purge protection
 - [ ] Mount as **files, not environment variables**; rotate on suspected exposure
@@ -83,6 +92,8 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Images & Supply Chain
+
+**Attack path:** a poisoned or unpinned image runs attacker code on every node.
 
 - [ ] Use a **private Azure Container Registry** with **Private Link** — never a public registry
 - [ ] Enable **vulnerability scanning** (Defender for Containers) and block critical findings
@@ -93,8 +104,10 @@ AKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Detection & Response
 
+**Attack path:** without audit logs and Defender signals, identity abuse and container escapes go unnoticed.
+
 - [ ] Enable **Microsoft Defender for Containers** for runtime threat detection
 - [ ] Send **control plane / audit logs** (`kube-audit`, `kube-apiserver`) to Log Analytics, retained outside the cluster's blast radius
 - [ ] Alert on: cluster-admin bindings, `exec` into pods, Secret reads, `listClusterAdminCredential` calls, Entra role changes
-- [ ] Scan posture regularly (**kube-bench**, **kubestriker**, AKS Periscope)
+- [ ] Benchmark the cluster against CIS with **kube-bench** and **kubestriker**
 - [ ] Rehearse **credential revocation** — rotate managed identities, Key Vault secrets, and cluster credentials

--- a/guides/account configurations/organizations/cloud-platforms/aws.md
+++ b/guides/account configurations/organizations/cloud-platforms/aws.md
@@ -6,7 +6,7 @@ scope: ORGANIZATION
 
 <div align="center">
   <img src="../../../../images/guides/aws.svg" alt="AWS Logo" width="64" height="64">
-  <h2><a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">AWS</a> Security Configuration Guide</h2>
+  <h2><a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">AWS</a> Configuration Guide</h2>
   <p><em>Identity, Network, Data, and Detection controls for AWS accounts</em></p>
 </div>
 

--- a/guides/account configurations/organizations/cloud-platforms/azure.md
+++ b/guides/account configurations/organizations/cloud-platforms/azure.md
@@ -6,7 +6,7 @@ scope: ORGANIZATION
 
 <div align="center">
   <img src="../../../../images/guides/azure.svg" alt="Azure Logo" width="64" height="64">
-  <h2><a href="https://azure.microsoft.com/" target="_blank" rel="noopener noreferrer">Azure</a> Security Configuration Guide</h2>
+  <h2><a href="https://azure.microsoft.com/" target="_blank" rel="noopener noreferrer">Azure</a> Configuration Guide</h2>
   <p><em>Identity, Network, Data, and Detection controls for Microsoft Azure accounts</em></p>
 </div>
 

--- a/guides/account configurations/organizations/cloud-platforms/eks.md
+++ b/guides/account configurations/organizations/cloud-platforms/eks.md
@@ -18,6 +18,8 @@ EKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Control Plane Access
 
+**Attack path:** a public API server or an unencrypted etcd snapshot exposes the whole cluster.
+
 - [ ] **Disable the public API endpoint** and use private access, or restrict `publicAccessCidrs` to known admin ranges — never `0.0.0.0/0`
 - [ ] Reach the cluster over **VPN, Direct Connect, or a bastion** in the VPC
 - [ ] Enable **envelope encryption of Secrets with a KMS CMK** so etcd contents are not readable from a snapshot
@@ -60,6 +62,8 @@ EKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Network Segmentation
 
+**Attack path:** a compromised pod reaches every service and node in the VPC.
+
 - [ ] Place nodes in **private subnets**; no public IPs on worker nodes
 - [ ] Enforce **default-deny NetworkPolicy** (VPC CNI network policy, Calico, or Cilium)
 - [ ] Use **security groups for pods** to isolate sensitive workloads at the ENI level
@@ -70,6 +74,8 @@ EKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Pod Security
 
+**Attack path:** a privileged or host-namespaced pod escapes to the node and its IAM role.
+
 - [ ] Enforce **Pod Security Admission `restricted`**; block privileged, hostPath, hostNetwork, hostPID
 - [ ] **Disable ServiceAccount token automount** where not needed
 - [ ] Run **non-root**, read-only root filesystem, all capabilities dropped, `seccompProfile: RuntimeDefault`
@@ -79,6 +85,8 @@ EKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Images & Supply Chain
 
+**Attack path:** a poisoned or unpinned image runs attacker code on every node.
+
 - [ ] Use **private ECR** repositories; block public registries at admission
 - [ ] Enable **ECR enhanced scanning** and fail deployments on critical findings
 - [ ] **Pin digests**, set `imagePullPolicy: Always` for mutable tags
@@ -87,6 +95,8 @@ EKS-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Detection & Response
+
+**Attack path:** without audit logs and runtime signals, IAM abuse and container escapes go unnoticed.
 
 - [ ] Enable **EKS control plane logging** (api, audit, authenticator) to CloudWatch and ship off-account
 - [ ] Enable **GuardDuty EKS Protection** (audit log monitoring **and** Runtime Monitoring)

--- a/guides/account configurations/organizations/cloud-platforms/gcp.md
+++ b/guides/account configurations/organizations/cloud-platforms/gcp.md
@@ -6,7 +6,7 @@ scope: ORGANIZATION
 
 <div align="center">
   <img src="../../../../images/guides/gcp.svg" alt="GCP Logo" width="64" height="64">
-  <h2><a href="https://cloud.google.com/" target="_blank" rel="noopener noreferrer">GCP</a> Security Configuration Guide</h2>
+  <h2><a href="https://cloud.google.com/" target="_blank" rel="noopener noreferrer">GCP</a> Configuration Guide</h2>
   <p><em>Identity, Network, Data, and Detection controls for Google Cloud accounts</em></p>
 </div>
 

--- a/guides/account configurations/organizations/cloud-platforms/gke.md
+++ b/guides/account configurations/organizations/cloud-platforms/gke.md
@@ -18,6 +18,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Control Plane Access
 
+**Attack path:** a public control plane or the read-only kubelet port exposes cluster and node data.
+
 - [ ] Run a **[private cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept)** — nodes get no public IPs
 - [ ] Restrict the control plane with **authorized networks**; never expose it to `0.0.0.0/0`
 - [ ] **Disable the kubelet read-only port (10255)** — it leaks pod and node data unauthenticated
@@ -50,6 +52,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Network Segmentation
 
+**Attack path:** a compromised pod reaches every service and node in the VPC.
+
 - [ ] Enable **[network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)** (Dataplane V2 / Cilium) and apply **default-deny ingress and egress**
 - [ ] Use **private nodes** with Cloud NAT for controlled egress
 - [ ] Restrict **VPC firewall rules** to required ports; no broad internal allow-all
@@ -58,6 +62,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Workload Privileges
+
+**Attack path:** a privileged or host-namespaced pod escapes to the node and its service account.
 
 - [ ] Enforce **Pod Security Admission `restricted`** (or Policy Controller equivalents)
 - [ ] Block **privileged**, hostPath, hostNetwork, hostPID; run **non-root** with dropped capabilities
@@ -69,6 +75,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 
 ## Secrets
 
+**Attack path:** a read Secret or leaked token grants standing access to project resources.
+
 - [ ] Store credentials in **Secret Manager**, not raw Kubernetes Secrets
 - [ ] Enable **[application-layer secrets encryption](https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets)** with Cloud KMS
 - [ ] Mount secrets as **files, not environment variables**; rotate on suspected exposure
@@ -76,6 +84,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Images & Supply Chain
+
+**Attack path:** a poisoned or unpinned image runs attacker code on every node.
 
 - [ ] Use **Artifact Registry** (private); block external registries at admission
 - [ ] Enforce **[Binary Authorization](https://cloud.google.com/binary-authorization/docs)** so only signed, attested images run
@@ -85,6 +95,8 @@ GKE-specific controls on top of the [Kubernetes](https://kubernetes.io/docs/conc
 ---
 
 ## Detection & Response
+
+**Attack path:** without audit logs and runtime signals, IAM abuse and container escapes go unnoticed.
 
 - [ ] Enable **Cloud Audit Logs** (admin + data access) and export to a **separate, restricted project**
 - [ ] Enable **VPC Flow Logs** and firewall rule logging for lateral-movement analysis

--- a/guides/account configurations/organizations/cloud-platforms/kubernetes.md
+++ b/guides/account configurations/organizations/cloud-platforms/kubernetes.md
@@ -78,6 +78,8 @@ Every item below maps to something an attacker actually does: reach the control 
 
 ## Secrets Handling
 
+**Attack path:** a read Secret or a leaked pod token grants standing access — logs, env dumps, and etcd all leak them.
+
 - [ ] **Mount Secrets as files, not environment variables** — env vars leak via crash dumps, logs, and `/proc`
 - [ ] Prefer an **external secret store** (Vault, cloud secret manager) over raw etcd Secrets
 - [ ] Scope Secret access with **`resourceNames`** so a workload reads only its own
@@ -86,6 +88,8 @@ Every item below maps to something an attacker actually does: reach the control 
 ---
 
 ## Supply Chain & Images
+
+**Attack path:** a poisoned or unpinned image runs attacker code on every pull.
 
 - [ ] Pull only from **trusted/private registries**; block public registries via admission policy
 - [ ] **Pin image digests** (not `:latest`) so the running image cannot change underneath you
@@ -96,6 +100,8 @@ Every item below maps to something an attacker actually does: reach the control 
 
 ## Admission Control
 
+**Attack path:** without enforcement at admission, a non-compliant pod slips past every policy above.
+
 - [ ] Enforce policy at admission with **ValidatingAdmissionPolicy**, **Kyverno**, or **OPA/Gatekeeper**
 - [ ] **Fail closed** — a webhook that fails open is not a control
 - [ ] Restrict who can modify **admission webhooks**; editing them disables every policy at once
@@ -103,6 +109,8 @@ Every item below maps to something an attacker actually does: reach the control 
 ---
 
 ## Node Isolation & Resource Abuse
+
+**Attack path:** a container escape lands on whatever shares the node; an unbounded pod starves it.
 
 - [ ] **Separate sensitive workloads onto dedicated nodes** (taints/affinity) so a container escape does not land next to secrets-bearing pods
 - [ ] Isolate tenants by **namespace + node pool**; use separate clusters for hostile multi-tenancy
@@ -112,6 +120,8 @@ Every item below maps to something an attacker actually does: reach the control 
 ---
 
 ## Audit Logging & Detection
+
+**Attack path:** an attacker with cluster-admin erases local logs and persists unseen.
 
 - [ ] **Enable API server audit logging** and ship it **off-cluster** — an attacker with cluster-admin can erase local logs
 - [ ] Alert on: `system:masters` use, new ClusterRoleBindings, `exec` into pods, Secret reads by unusual identities, failed auth spikes


### PR DESCRIPTION
Cleanup pass on the Cloud Platforms guides.

- **Consistent attack-path framing** — the Kubernetes/EKS/GKE/AKS guides had an `**Attack path:**` line on only some sections. Now every section has one, so the pattern is deliberate rather than half-applied.
- **AKS item fixes** — merged two redundant version/auto-upgrade items into one; replaced the generic "scan posture regularly" item and dropped **AKS Periscope** (a diagnostics/log-collection tool, not a security scanner).
- **Title normalization** — AWS/Azure/GCP `<h2>` said "Security Configuration Guide", which the ingestion title parser doesn't match, so they rendered as bare "Aws"/"Azure"/"Gcp". Dropped "Security" so they parse as "AWS/Azure/GCP Configuration", consistent with every other guide.

No new controls added; ids and content otherwise unchanged, so user progress is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)