### PR TITLE
Add 20 remediation guides for common org security findings

### DIFF
--- a/guides/recon/attack-surface-reduction.md
+++ b/guides/recon/attack-surface-reduction.md
@@ -1,0 +1,39 @@
+<!--
+id: attack-surface-reduction
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Reduce Your Public Attack Surface</h1>
+  <p><em>Take non-production and admin hosts off the open internet</em></p>
+</div>
+
+---
+
+## Overview
+
+Every host that resolves publicly is something an attacker can probe. Staging environments, admin panels, internal tools, CI servers and forgotten subdomains are frequently less hardened than production, run older code, and leak internal detail — so an attacker treats them as the soft way in. This guide helps you find what is exposed and pull the sensitive parts back behind authentication or off the internet entirely.
+
+---
+
+## Inventory and Trim Exposed Hosts
+
+### Why It's Critical
+
+Reconnaissance against a web3 org routinely turns up `staging.`, `admin.`, `vpn.`, `git.` and `jenkins.` subdomains that were never meant to face the public. These are high-value targets: a login page on an internal tool, an unauthenticated dashboard, or a dev build with debug endpoints can hand an attacker credentials, source, or a foothold.
+
+### Implementation Steps
+
+- [ ] Enumerate all subdomains that resolve publicly (certificate transparency logs, DNS records, and your DNS provider's zone file are the sources of truth).
+- [ ] For each host, decide: does this need to be reachable from the public internet at all?
+- [ ] Put admin panels, internal tools, dashboards and CI/CD behind your VPN, an SSO/identity-aware proxy, or an IP allow-list.
+- [ ] Remove DNS records for hosts that are no longer used, so they stop appearing in recon.
+- [ ] Ensure any host that must stay public is patched and access-controlled to the same standard as production.
+- [ ] Add subdomain discovery to your regular monitoring so new exposed hosts are caught quickly.
+
+---
+
+## Notes
+
+"Security through obscurity" is not the goal — the goal is that non-production and privileged surfaces require authentication. Assume every subdomain you publish will be found; make sure the sensitive ones ask for credentials.

--- a/guides/recon/brand-impersonation-response.md
+++ b/guides/recon/brand-impersonation-response.md
@@ -28,7 +28,7 @@ The damage from impersonation lands on your community and your reputation even w
 - [ ] Confirm you do not own the domain and capture evidence (screenshots, WHOIS, resolving IP, any mail records).
 - [ ] File abuse / takedown reports with the domain's registrar and its hosting provider.
 - [ ] Report the domain to phishing feeds — Google Safe Browsing, and for web3, Chainabuse (https://chainabuse.com/) — so wallets and browsers warn users.
-- [ ] Warn your community through your official, verified channels with the exact malicious domain so they can recognise it.
+- [ ] Warn your community through your official, verified channels with the exact malicious domain so they can recognize it.
 - [ ] If it targets a specific campaign (a token launch, an airdrop), coordinate the warning with that announcement.
 
 ---
@@ -45,4 +45,4 @@ The damage from impersonation lands on your community and your reputation even w
 
 ## Notes
 
-Prioritise look-alikes that have a mail server configured — those can phish by email *and* host a fake site, and are the most dangerous.
+Prioritize look-alikes that have a mail server configured — those can phish by email *and* host a fake site, and are the most dangerous.

--- a/guides/recon/brand-impersonation-response.md
+++ b/guides/recon/brand-impersonation-response.md
@@ -1,0 +1,48 @@
+<!--
+id: brand-impersonation-response
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Respond to Brand Impersonation</h1>
+  <p><em>Take down look-alike domains and phishing infrastructure</em></p>
+</div>
+
+---
+
+## Overview
+
+Attackers register look-alike domains — typos, homoglyphs, extra words like `-claim` or `-airdrop`, alternate TLDs — to phish your users. A registered look-alike with a mail server is a complete impersonation kit: it can send convincing email and host a matching drainer or fake-login page. This guide covers responding to a live look-alike and reducing the risk of new ones.
+
+---
+
+## Take Down an Active Look-Alike
+
+### Why It's Critical
+
+The damage from impersonation lands on your community and your reputation even when your own infrastructure is untouched. A look-alike domain is the standard host for pages that harvest credentials or drain wallets from users who mistype or follow a fake link.
+
+### Implementation Steps
+
+- [ ] Confirm you do not own the domain and capture evidence (screenshots, WHOIS, resolving IP, any mail records).
+- [ ] File abuse / takedown reports with the domain's registrar and its hosting provider.
+- [ ] Report the domain to phishing feeds — Google Safe Browsing, and for web3, Chainabuse (https://chainabuse.com/) — so wallets and browsers warn users.
+- [ ] Warn your community through your official, verified channels with the exact malicious domain so they can recognise it.
+- [ ] If it targets a specific campaign (a token launch, an airdrop), coordinate the warning with that announcement.
+
+---
+
+## Reduce Future Risk
+
+### Implementation Steps
+
+- [ ] Defensively register the highest-risk permutations of your brand (common typos, `-app`, `.xyz`, key TLDs).
+- [ ] Monitor certificate-transparency logs and new domain registrations for look-alikes continuously.
+- [ ] Publish a canonical list of your official domains and channels on your own site so users have a source of truth.
+
+---
+
+## Notes
+
+Prioritise look-alikes that have a mail server configured — those can phish by email *and* host a fake site, and are the most dangerous.

--- a/guides/recon/contract-security.md
+++ b/guides/recon/contract-security.md
@@ -1,0 +1,52 @@
+<!--
+id: contract-security
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Secure Contract Upgradeability and Admin Keys</h1>
+  <p><em>Put upgrade and owner rights behind a multisig, never a single key</em></p>
+</div>
+
+---
+
+## Overview
+
+An upgradeable contract is only as trustworthy as whoever controls its upgrade key. If that authority is a single externally owned account, one private key can replace the contract's entire logic with a malicious version and drain every balance it holds — the single most dangerous contract-governance mistake in web3. The same applies to privileged `owner()` powers like pause, mint, fee changes and withdrawals. This guide covers putting those rights behind proper governance.
+
+---
+
+## Protect the Upgrade Authority
+
+### Why It's Critical
+
+Whoever can push a new implementation to a proxy effectively owns the contract and everything in it. A single-key upgrade authority is a catastrophic single point of failure; a multisig with a timelock makes upgrades require multiple approvals and gives the community time to react.
+
+### Implementation Steps
+
+- [ ] Identify who controls upgrades for each proxy (the proxy admin, or the owner for UUPS-style proxies).
+- [ ] Transfer the upgrade authority to a multisig (e.g. a Gnosis Safe) with an appropriate signer threshold and hardware-wallet signers.
+- [ ] Add a timelock in front of upgrades so changes are announced and delayed, not instant and silent.
+- [ ] For contracts that no longer need to change, consider making them immutable (renounce upgradeability).
+
+---
+
+## Protect Privileged Owner Roles
+
+### Why It's Critical
+
+Ownable-style privileged functions (pause, mint, set fees, withdraw) gated on a single key give an attacker who steals that key enough power to freeze, mint, or drain.
+
+### Implementation Steps
+
+- [ ] Transfer contract ownership / admin roles to a multisig, not an EOA.
+- [ ] Scope privileged functions to the minimum necessary and document what each can do.
+- [ ] Renounce ownership entirely where the privileged functions are no longer needed.
+- [ ] Monitor admin/owner addresses on-chain for unexpected transactions.
+
+---
+
+## Notes
+
+"Upgrade authority" (who can replace the code) and "owner" (who holds privileged functions) are often *different* accounts on the same contract — secure both. A contract can be upgradeable and Ownable at once.

--- a/guides/recon/contract-verification.md
+++ b/guides/recon/contract-verification.md
@@ -1,0 +1,38 @@
+<!--
+id: contract-verification
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Verify Your Contract Source</h1>
+  <p><em>Let users and auditors read what you deploy</em></p>
+</div>
+
+---
+
+## Overview
+
+An unverified contract is a black box: users are asked to send funds to, and approve, bytecode that neither they nor independent auditors can read. Verifying your source code on block explorers is a baseline transparency and trust measure — and it makes it far easier for the community and security researchers to catch a problem before it becomes an incident. This guide covers verifying your deployed contracts.
+
+---
+
+## Publish and Verify Source
+
+### Why It's Critical
+
+Unverified contracts erode user trust and can hide malicious or buggy behaviour. Verified source lets anyone confirm the deployed bytecode matches the published code and understand exactly what the contract does.
+
+### Implementation Steps
+
+- [ ] Verify the source of every deployed contract on the block explorers your users rely on (Etherscan and equivalents for each chain you deploy to).
+- [ ] Ensure the verified source matches the exact compiler version and settings used for deployment, so the bytecode matches.
+- [ ] Verify proxy implementation contracts as well as the proxies themselves.
+- [ ] Publish the source in your public repository and link it from your docs.
+- [ ] Consider a public audit and publish the report alongside the verified source.
+
+---
+
+## Notes
+
+Verification is transparency, not a security guarantee on its own — but an unverified contract asking users for approvals is a red flag they are right to distrust. Pair verification with an audit for anything holding real value.

--- a/guides/recon/cors-hardening.md
+++ b/guides/recon/cors-hardening.md
@@ -1,0 +1,38 @@
+<!--
+id: cors-hardening
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Lock Down Your CORS Policy</h1>
+  <p><em>Stop arbitrary sites from reading your app's responses</em></p>
+</div>
+
+---
+
+## Overview
+
+CORS (Cross-Origin Resource Sharing) controls which other websites' JavaScript is allowed to read responses from your app. A policy that reflects any origin back in `Access-Control-Allow-Origin` — especially combined with `Access-Control-Allow-Credentials: true` — lets any malicious website a logged-in user visits read their authenticated data from your app. This guide covers replacing origin reflection with a strict allow-list.
+
+---
+
+## Replace Origin Reflection with an Allow-List
+
+### Why It's Critical
+
+If your server echoes back whatever `Origin` a request carries, its CORS policy effectively trusts the entire internet. With credentials allowed, this becomes a direct cross-origin data- and session-theft primitive: an attacker's page makes authenticated requests to your API in the victim's session and reads the responses.
+
+### Implementation Steps
+
+- [ ] Confirm the misconfiguration: send a request with an untrusted `Origin` header and check whether it is reflected in the `Access-Control-Allow-Origin` response header.
+- [ ] Replace any origin-reflection logic with a fixed allow-list of the specific trusted origins that legitimately need cross-origin access.
+- [ ] Never combine a reflected or wildcard (`*`) `Access-Control-Allow-Origin` with `Access-Control-Allow-Credentials: true`.
+- [ ] For public, unauthenticated APIs, a wildcard origin without credentials is acceptable — but confirm no sensitive or authenticated data is served from that origin.
+- [ ] Scope allowed methods and headers to only what each endpoint needs.
+
+---
+
+## Notes
+
+The dangerous combination is *reflected origin + credentials*. A static wildcard on a genuinely public, credential-free endpoint is usually fine; reflecting the caller's origin almost never is.

--- a/guides/recon/credential-hygiene.md
+++ b/guides/recon/credential-hygiene.md
@@ -1,0 +1,51 @@
+<!--
+id: credential-hygiene
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Contain Breached Credentials</h1>
+  <p><em>Kill password reuse before it becomes account takeover</em></p>
+</div>
+
+---
+
+## Overview
+
+Corporate email addresses turn up in third-party breaches and infostealer logs constantly. The real danger is reuse: if a password exposed in some unrelated breach is also used on a corporate system, an attacker can log straight in — credential stuffing is the single most common initial-access technique. This guide covers responding when a team member's credentials are found exposed, and making the whole class of attack ineffective.
+
+---
+
+## Respond to an Exposed Account
+
+### Why It's Critical
+
+An exposed password is only dangerous if it still works somewhere. The response is to invalidate it everywhere and confirm it isn't reused.
+
+### Implementation Steps
+
+- [ ] Force a password reset for the exposed account.
+- [ ] Confirm the password is not reused on any other corporate system (SSO, email, cloud consoles, internal tools).
+- [ ] Require phishing-resistant MFA on the account (security key or passkey), so an exposed password alone is not enough to log in.
+- [ ] Review recent sign-in activity for that account for signs it was already used.
+
+---
+
+## Make Reuse Impossible
+
+### Why It's Critical
+
+You cannot stop your addresses from appearing in other companies' breaches — you can make sure those leaked passwords are useless against you.
+
+### Implementation Steps
+
+- [ ] Roll out a password manager across the organisation so every account has a unique, strong, generated password.
+- [ ] Enforce MFA org-wide (see the enforce-2FA guide).
+- [ ] Monitor breach and stealer-log sources for your domains so new exposures are caught quickly.
+
+---
+
+## Notes
+
+A password manager plus enforced MFA turns a breached-credential finding from an incident into a non-event — the leaked password no longer opens anything.

--- a/guides/recon/credential-hygiene.md
+++ b/guides/recon/credential-hygiene.md
@@ -40,7 +40,7 @@ You cannot stop your addresses from appearing in other companies' breaches — y
 
 ### Implementation Steps
 
-- [ ] Roll out a password manager across the organisation so every account has a unique, strong, generated password.
+- [ ] Roll out a password manager across the organization so every account has a unique, strong, generated password.
 - [ ] Enforce MFA org-wide (see the enforce-2FA guide).
 - [ ] Monitor breach and stealer-log sources for your domains so new exposures are caught quickly.
 

--- a/guides/recon/dependency-management.md
+++ b/guides/recon/dependency-management.md
@@ -25,7 +25,7 @@ A vulnerability with a published advisory is a vulnerability with a published ex
 
 ### Implementation Steps
 
-- [ ] Review the flagged dependencies and their advisories; prioritise CRITICAL and HIGH severity.
+- [ ] Review the flagged dependencies and their advisories; prioritize CRITICAL and HIGH severity.
 - [ ] Upgrade each affected package to a patched version; where no fix exists, evaluate a replacement or a temporary mitigation.
 - [ ] Re-run the dependency audit to confirm the findings clear.
 - [ ] Verify your lockfile pins the fixed versions so the patch actually ships.

--- a/guides/recon/dependency-management.md
+++ b/guides/recon/dependency-management.md
@@ -1,0 +1,52 @@
+<!--
+id: dependency-management
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Manage Vulnerable Dependencies</h1>
+  <p><em>Patch what you ship and automate the upkeep</em></p>
+</div>
+
+---
+
+## Overview
+
+Your application is mostly other people's code. Known-vulnerable dependencies are exploited by automated tooling at scale, and a single vulnerable package can compromise your build pipeline or your runtime. For web3, a compromised dependency in a front-end is a well-trodden path to injecting a wallet drainer. This guide covers patching current findings and keeping dependencies current going forward.
+
+---
+
+## Patch Known-Vulnerable Packages
+
+### Why It's Critical
+
+A vulnerability with a published advisory is a vulnerability with a published exploit. The gap between disclosure and mass scanning is short, so unpatched dependencies are low-hanging fruit.
+
+### Implementation Steps
+
+- [ ] Review the flagged dependencies and their advisories; prioritise CRITICAL and HIGH severity.
+- [ ] Upgrade each affected package to a patched version; where no fix exists, evaluate a replacement or a temporary mitigation.
+- [ ] Re-run the dependency audit to confirm the findings clear.
+- [ ] Verify your lockfile pins the fixed versions so the patch actually ships.
+
+---
+
+## Automate Ongoing Updates
+
+### Why It's Critical
+
+Dependency risk is continuous — new advisories land daily. Manual, periodic review lets vulnerabilities sit unpatched for weeks.
+
+### Implementation Steps
+
+- [ ] Enable automated dependency-update PRs (Dependabot / Renovate) on every repository.
+- [ ] Turn on your platform's vulnerability alerts.
+- [ ] Pin dependencies with a lockfile and review new transitive dependencies before merging.
+- [ ] Prefer well-maintained packages; treat an unmaintained dependency as a latent risk.
+
+---
+
+## Notes
+
+Automated update PRs only help if someone reviews and merges them — assign ownership so security patches don't pile up unmerged.

--- a/guides/recon/dns-hardening.md
+++ b/guides/recon/dns-hardening.md
@@ -1,0 +1,52 @@
+<!--
+id: dns-hardening
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Harden Your DNS</h1>
+  <p><em>Protect name resolution and certificate issuance</em></p>
+</div>
+
+---
+
+## Overview
+
+DNS is the foundation everything else trusts: if an attacker can forge DNS answers or obtain a certificate for your domain, they can redirect and impersonate you. Two records close those doors — DNSSEC signs your DNS responses so they cannot be forged in transit, and CAA restricts which certificate authorities are allowed to issue certificates for your domain. This guide covers enabling both.
+
+---
+
+## Enable DNSSEC
+
+### Why It's Critical
+
+Without DNSSEC, a resolver that an attacker can poison will happily hand your users forged DNS answers, pointing your domain at infrastructure the attacker controls. DNSSEC cryptographically signs your zone so tampered answers are rejected.
+
+### Implementation Steps
+
+- [ ] Enable DNSSEC at your DNS host / provider for the zone.
+- [ ] Publish the resulting DS (Delegation Signer) record at your domain registrar to complete the chain of trust.
+- [ ] Verify the chain validates (use a DNSSEC analyser); a broken chain can take your domain offline, so confirm it before considering the change done.
+- [ ] Document the key-rollover process your provider uses so future rotations don't break resolution.
+
+---
+
+## Publish CAA Records
+
+### Why It's Critical
+
+By default any certificate authority in the world can issue a certificate for your domain. A single mis-issued or fraudulently obtained certificate enables a convincing man-in-the-middle attack. CAA records name the only CAs you actually use.
+
+### Implementation Steps
+
+- [ ] Publish CAA records naming only your CA(s), e.g. `yourdomain.com. CAA 0 issue "letsencrypt.org"`.
+- [ ] Add an `iodef` record so you're notified of issuance attempts, e.g. `0 iodef "mailto:security@yourdomain.com"`.
+- [ ] Include `issuewild` restrictions if you use wildcard certificates.
+- [ ] Re-check CAA whenever you change certificate providers.
+
+---
+
+## Notes
+
+DNSSEC and CAA are both "set once, benefit forever" controls. The only real risk is a misconfigured DNSSEC chain, so validate it immediately after enabling.

--- a/guides/recon/dns-hardening.md
+++ b/guides/recon/dns-hardening.md
@@ -27,7 +27,7 @@ Without DNSSEC, a resolver that an attacker can poison will happily hand your us
 
 - [ ] Enable DNSSEC at your DNS host / provider for the zone.
 - [ ] Publish the resulting DS (Delegation Signer) record at your domain registrar to complete the chain of trust.
-- [ ] Verify the chain validates (use a DNSSEC analyser); a broken chain can take your domain offline, so confirm it before considering the change done.
+- [ ] Verify the chain validates (use a DNSSEC analyzer); a broken chain can take your domain offline, so confirm it before considering the change done.
 - [ ] Document the key-rollover process your provider uses so future rotations don't break resolution.
 
 ---

--- a/guides/recon/email-dkim.md
+++ b/guides/recon/email-dkim.md
@@ -1,0 +1,39 @@
+<!--
+id: email-dkim
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Enable DKIM Signing</h1>
+  <p><em>Cryptographically sign your outbound mail</em></p>
+</div>
+
+---
+
+## Overview
+
+DKIM (DomainKeys Identified Mail) attaches a cryptographic signature to every message your mail platform sends, and publishes the matching public key in DNS. Receivers verify the signature to confirm the mail genuinely came from you and was not tampered with in transit. Without DKIM, your mail is easier to spoof, and DMARC has only SPF to rely on — which breaks the moment a message is forwarded. This guide covers enabling DKIM on your mail platform and publishing the key.
+
+---
+
+## Turn On DKIM for Your Domain
+
+### Why It's Critical
+
+DKIM survives mail forwarding where SPF does not, so it is the more robust of the two authentication mechanisms DMARC depends on. A domain with no DKIM selectors has a real gap: legitimate mail is easier to forge, and DMARC enforcement is far more likely to misfire and quarantine your own messages.
+
+### Implementation Steps
+
+- [ ] In your mail platform's admin console, enable DKIM signing for your domain (Google Workspace: Apps > Google Workspace > Gmail > Authenticate email; Microsoft 365: Defender portal > Email authentication settings).
+- [ ] Copy the DKIM public key / CNAME records the platform provides.
+- [ ] Publish them in DNS at the selector host the platform specifies, e.g. `google._domainkey.yourdomain.com` or `selector1._domainkey.yourdomain.com`.
+- [ ] Enable signing for **every** service that sends mail as your domain (transactional and marketing providers each have their own selector and key).
+- [ ] Wait for DNS propagation, then turn on signing in the platform and send a test message.
+- [ ] Verify the received message shows `dkim=pass` in its authentication results header.
+
+---
+
+## Notes
+
+DKIM selectors are not discoverable — automated scanners probe common selector names, so a custom selector may not be detected externally even when DKIM is correctly configured. Confirm signing is on by inspecting the authentication headers of a real received message rather than relying on an external probe.

--- a/guides/recon/email-dmarc.md
+++ b/guides/recon/email-dmarc.md
@@ -1,0 +1,40 @@
+<!--
+id: email-dmarc
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Roll Out DMARC to Enforcement</h1>
+  <p><em>Move from monitoring to actually blocking spoofed mail</em></p>
+</div>
+
+---
+
+## Overview
+
+DMARC ties SPF and DKIM together and tells receiving mail servers what to do with mail that fails authentication — and, just as importantly, sends you reports of who is sending mail as your domain. A missing DMARC record leaves spoofing unblocked and invisible; a `p=none` policy only watches without protecting. This guide takes you from no DMARC (or monitor-only DMARC) to full `p=reject` enforcement safely, without breaking legitimate mail.
+
+---
+
+## Publish and Enforce a DMARC Policy
+
+### Why It's Critical
+
+Even with SPF and DKIM in place, without DMARC there is no instruction telling receivers to reject mail that fails those checks, and no visibility into abuse. Attackers exploit this to impersonate your domain against staff, investors and community members. Moving to `p=reject` is what makes a spoofed email from your domain actually bounce.
+
+### Implementation Steps
+
+- [ ] Publish a DMARC record as a TXT entry at `_dmarc.yourdomain.com` starting in monitor mode: `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`.
+- [ ] Collect and review the aggregate (`rua`) reports for 1–4 weeks — use a DMARC report analyser — until every legitimate sending source passes SPF or DKIM alignment.
+- [ ] Fix any legitimate sources that are failing (add them to SPF, enable DKIM signing) before tightening the policy.
+- [ ] Raise the policy to `p=quarantine` and monitor for a further week.
+- [ ] Raise the policy to `p=reject` — full enforcement.
+- [ ] Ensure `pct` is unset or `pct=100` so the policy applies to all mail, not a sample.
+- [ ] Keep a monitored `rua` address in place permanently so you keep seeing spoofing attempts.
+
+---
+
+## Notes
+
+Do not jump straight to `p=reject` — publish `p=none` first and read the reports, or you risk quarantining your own legitimate mail (newsletters, forwarders, third-party senders you forgot about). The reporting phase is what makes enforcement safe.

--- a/guides/recon/email-dmarc.md
+++ b/guides/recon/email-dmarc.md
@@ -26,7 +26,7 @@ Even with SPF and DKIM in place, without DMARC there is no instruction telling r
 ### Implementation Steps
 
 - [ ] Publish a DMARC record as a TXT entry at `_dmarc.yourdomain.com` starting in monitor mode: `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`.
-- [ ] Collect and review the aggregate (`rua`) reports for 1–4 weeks — use a DMARC report analyser — until every legitimate sending source passes SPF or DKIM alignment.
+- [ ] Collect and review the aggregate (`rua`) reports for 1–4 weeks — use a DMARC report analyzer — until every legitimate sending source passes SPF or DKIM alignment.
 - [ ] Fix any legitimate sources that are failing (add them to SPF, enable DKIM signing) before tightening the policy.
 - [ ] Raise the policy to `p=quarantine` and monitor for a further week.
 - [ ] Raise the policy to `p=reject` — full enforcement.

--- a/guides/recon/email-spf.md
+++ b/guides/recon/email-spf.md
@@ -13,7 +13,7 @@ scope: ORGANIZATION
 
 ## Overview
 
-SPF (Sender Policy Framework) is a DNS TXT record that lists which mail servers are allowed to send email on behalf of your domain. Without it — or with a permissive version of it — anyone on the internet can send mail that appears to come from your domain, which is the opening move in most phishing and business-email-compromise attacks against a web3 team and its community. This guide walks you through publishing an SPF record that authorises only your real senders and rejects everyone else.
+SPF (Sender Policy Framework) is a DNS TXT record that lists which mail servers are allowed to send email on behalf of your domain. Without it — or with a permissive version of it — anyone on the internet can send mail that appears to come from your domain, which is the opening move in most phishing and business-email-compromise attacks against a web3 team and its community. This guide walks you through publishing an SPF record that authorizes only your real senders and rejects everyone else.
 
 ---
 
@@ -21,7 +21,7 @@ SPF (Sender Policy Framework) is a DNS TXT record that lists which mail servers 
 
 ### Why It's Critical
 
-Receiving mail servers use SPF to decide whether a message that claims to be from your domain actually came from an authorised server. A missing record means no such check happens. A record ending in `+all` authorises the entire internet, and `?all` (neutral) or `~all` (softfail) still let unauthorised mail through — spoofed mail can land in inboxes and get users to click, connect a wallet, or approve a transaction.
+Receiving mail servers use SPF to decide whether a message that claims to be from your domain actually came from an authorized server. A missing record means no such check happens. A record ending in `+all` authorizes the entire internet, and `?all` (neutral) or `~all` (softfail) still let unauthorized mail through — spoofed mail can land in inboxes and get users to click, connect a wallet, or approve a transaction.
 
 ### Implementation Steps
 

--- a/guides/recon/email-spf.md
+++ b/guides/recon/email-spf.md
@@ -1,0 +1,39 @@
+<!--
+id: email-spf
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Publish a Strict SPF Record</h1>
+  <p><em>Stop attackers from sending email as your domain</em></p>
+</div>
+
+---
+
+## Overview
+
+SPF (Sender Policy Framework) is a DNS TXT record that lists which mail servers are allowed to send email on behalf of your domain. Without it — or with a permissive version of it — anyone on the internet can send mail that appears to come from your domain, which is the opening move in most phishing and business-email-compromise attacks against a web3 team and its community. This guide walks you through publishing an SPF record that authorises only your real senders and rejects everyone else.
+
+---
+
+## Fix a Missing or Weak SPF Record
+
+### Why It's Critical
+
+Receiving mail servers use SPF to decide whether a message that claims to be from your domain actually came from an authorised server. A missing record means no such check happens. A record ending in `+all` authorises the entire internet, and `?all` (neutral) or `~all` (softfail) still let unauthorised mail through — spoofed mail can land in inboxes and get users to click, connect a wallet, or approve a transaction.
+
+### Implementation Steps
+
+- [ ] Enumerate every service that legitimately sends mail as your domain (Google Workspace / Microsoft 365, transactional providers like SendGrid or Postmark, marketing tools, ticketing systems).
+- [ ] Publish a single SPF TXT record at your root domain (`@`) that `include:`s each provider, e.g. `v=spf1 include:_spf.google.com include:sendgrid.net -all`.
+- [ ] End the record with `-all` (hardfail) so unlisted senders are rejected, not merely flagged.
+- [ ] Keep the record within the RFC 7208 limit of **10 DNS lookups** — flatten or remove unused `include:` mechanisms if you exceed it, or SPF silently fails on strict receivers.
+- [ ] Publish `v=spf1 -all` on any parked domain that never sends mail, so it cannot be spoofed either.
+- [ ] Verify with a checker (e.g. an SPF/MX lookup tool) that the record resolves and reports no permerror.
+
+---
+
+## Notes
+
+SPF alone is not enough: it breaks when mail is forwarded, so pair it with DKIM and an enforcing DMARC policy (see the DKIM and DMARC guides). All three together are what actually stops domain spoofing.

--- a/guides/recon/enforce-2fa.md
+++ b/guides/recon/enforce-2fa.md
@@ -13,7 +13,7 @@ scope: ORGANIZATION
 
 ## Overview
 
-Multi-factor authentication is the single highest-leverage identity control an organisation can turn on. Credential phishing and breach-password reuse are the two most common ways attackers get in, and enforced MFA neutralises both: a stolen password alone no longer opens anything. This guide covers enforcing MFA across the org and using phishing-resistant factors where it matters most.
+Multi-factor authentication is the single highest-leverage identity control an organization can turn on. Credential phishing and breach-password reuse are the two most common ways attackers get in, and enforced MFA neutralizes both: a stolen password alone no longer opens anything. This guide covers enforcing MFA across the org and using phishing-resistant factors where it matters most.
 
 ---
 

--- a/guides/recon/enforce-2fa.md
+++ b/guides/recon/enforce-2fa.md
@@ -1,0 +1,50 @@
+<!--
+id: enforce-2fa
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Enforce Multi-Factor Authentication</h1>
+  <p><em>One phished password should not be enough</em></p>
+</div>
+
+---
+
+## Overview
+
+Multi-factor authentication is the single highest-leverage identity control an organisation can turn on. Credential phishing and breach-password reuse are the two most common ways attackers get in, and enforced MFA neutralises both: a stolen password alone no longer opens anything. This guide covers enforcing MFA across the org and using phishing-resistant factors where it matters most.
+
+---
+
+## Enforce MFA Organization-Wide
+
+### Why It's Critical
+
+If MFA is optional, the accounts that skip it are exactly the ones an attacker needs. Enforcement — not encouragement — is what closes the gap. Without it, one careless click on a phishing link is enough for a full account takeover.
+
+### Implementation Steps
+
+- [ ] Turn on organization-wide MFA enforcement in your identity provider / SSO.
+- [ ] Set a deadline and enroll every member; remove or suspend accounts that don't comply by the cutoff.
+- [ ] Cover every critical system — email, code hosting, cloud consoles, deployment, and treasury tooling.
+
+---
+
+## Require Phishing-Resistant Factors for High-Value Roles
+
+### Why It's Critical
+
+SMS and even TOTP codes can be phished in real time by a convincing fake login page. Hardware security keys and passkeys (FIDO2/WebAuthn) are bound to the real origin and cannot be relayed to an attacker.
+
+### Implementation Steps
+
+- [ ] Require hardware security keys or passkeys for admins, finance, and treasury/multisig signers.
+- [ ] Register a backup factor per user to avoid lockouts.
+- [ ] Prefer authenticator apps or security keys over SMS for everyone else.
+
+---
+
+## Notes
+
+Enforced MFA turns a leaked or phished password from a breach into a non-event. Phishing-resistant factors go one step further and defeat the real-time phishing kits that beat ordinary MFA.

--- a/guides/recon/multisig-treasury.md
+++ b/guides/recon/multisig-treasury.md
@@ -1,0 +1,48 @@
+<!--
+id: multisig-treasury
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Move Treasury to a Multisig</h1>
+  <p><em>No single key should control the funds</em></p>
+</div>
+
+---
+
+## Overview
+
+The most common catastrophic mistake in web3 is holding treasury funds in a single-key wallet (an externally owned account). A single key has no protection: if it is phished, malware-stolen, or lost, the entire balance is gone with no recovery and no second approval to stop it — the failure mode behind many of the largest treasury losses on record. This guide covers moving to a multisig and running it well.
+
+---
+
+## Adopt a Multisig for Treasury
+
+### Why It's Critical
+
+A multisig requires multiple independent signers to approve any transfer, so compromising one key is not enough to move funds. It turns a single point of failure into a set of approvals an attacker cannot forge.
+
+### Implementation Steps
+
+- [ ] Deploy a battle-tested multisig (e.g. a Gnosis Safe) for treasury funds.
+- [ ] Choose a signer threshold that balances security and availability (e.g. 3-of-5); never use 1-of-N.
+- [ ] Put each signer key on a separate hardware wallet, held by a different trusted person.
+- [ ] Move treasury funds off any single-key wallet into the multisig; keep only small operational float in hot wallets.
+- [ ] Document who the signers are, how to reach them, and the recovery process if a signer is unavailable.
+
+---
+
+## Operate It Safely
+
+### Implementation Steps
+
+- [ ] Verify every transaction's details on the hardware wallet screen before signing (see transaction-verification guidance).
+- [ ] Review and rotate signers when team members change.
+- [ ] Consider a timelock for large or sensitive operations so they are public and delayed.
+
+---
+
+## Notes
+
+A multisig only helps if the signer keys are genuinely independent — different people, different hardware. Five signers on one laptop is still one point of failure.

--- a/guides/recon/phishing-resistance.md
+++ b/guides/recon/phishing-resistance.md
@@ -1,0 +1,38 @@
+<!--
+id: phishing-resistance
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Build Phishing Resistance</h1>
+  <p><em>Defend the people an attacker will target by name</em></p>
+</div>
+
+---
+
+## Overview
+
+Before touching infrastructure, an attacker builds a target list: who works here and what their email addresses are. Corporate email formats are predictable, so given a name, an attacker can derive the address — you cannot hide the pattern, so you defend the people behind it. This guide covers the human-side controls that make a targeted phishing campaign fail.
+
+---
+
+## Harden Your People Against Targeted Phishing
+
+### Why It's Critical
+
+Predictable email formats let an attacker enumerate your whole staff without any special access. High-value roles — finance, treasury signers, admins — are singled out deliberately. Technical controls plus aware humans are what stop the campaign.
+
+### Implementation Steps
+
+- [ ] Enforce phishing-resistant MFA (security keys / passkeys) so a phished password is useless (see the enforce-2FA guide).
+- [ ] Run periodic phishing simulations and share the results as training, not punishment.
+- [ ] Make sure high-value-role holders know they are named targets and how to report a suspicious message quickly.
+- [ ] Establish out-of-band verification for sensitive requests (fund transfers, key operations, access changes) — a second channel confirms the request is real.
+- [ ] Give everyone a fast, blameless way to report a suspected phish.
+
+---
+
+## Notes
+
+The email pattern itself is not a vulnerability to fix — it is inherent. The finding is a prompt to make sure the humans on that target list are protected by MFA and know the playbook.

--- a/guides/recon/secret-rotation.md
+++ b/guides/recon/secret-rotation.md
@@ -1,0 +1,47 @@
+<!--
+id: secret-rotation
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Rotate Leaked Secrets and Stop the Leak</h1>
+  <p><em>Treat any committed secret as already compromised</em></p>
+</div>
+
+---
+
+## Overview
+
+A secret committed to a repository — an API key, a token, a private key or mnemonic — must be treated as compromised the moment it lands in git history, even if the commit is later removed. Public repositories are scraped continuously by automated tools looking for exactly this. For a web3 project a committed deployer or signer key means direct, irreversible loss of funds. This guide covers rotating the secret and preventing recurrence.
+
+---
+
+## Rotate Immediately
+
+### Why It's Critical
+
+The window between a secret being pushed and being abused is often minutes. Removing the commit does not help — the value is already out. The only safe assumption is that it is compromised.
+
+### Implementation Steps
+
+- [ ] Rotate the exposed secret right now — revoke the old value and issue a new one.
+- [ ] For an on-chain key, move funds and privileges to a new key (or multisig) that was never exposed; the leaked key can never be trusted again.
+- [ ] Remove the secret from git history (e.g. `git filter-repo`) and force-push, then have collaborators re-clone.
+- [ ] Review logs for use of the leaked credential during the exposure window.
+
+---
+
+## Prevent Recurrence
+
+### Implementation Steps
+
+- [ ] Move secrets into a managed secret store / environment injection, never into the repository.
+- [ ] Add pre-commit secret scanning (e.g. gitleaks) so secrets are blocked before they are committed.
+- [ ] Enable your platform's push protection / secret scanning on all repositories, public and private.
+
+---
+
+## Notes
+
+Rotation is the whole job. Scrubbing history is good hygiene but does nothing to protect the value that already leaked — rotate first, scrub second.

--- a/guides/recon/secrets-exposure.md
+++ b/guides/recon/secrets-exposure.md
@@ -1,0 +1,51 @@
+<!--
+id: secrets-exposure
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Remove Exposed Files and Rotate Secrets</h1>
+  <p><em>Get source and environment files off your web root</em></p>
+</div>
+
+---
+
+## Overview
+
+When a `.git/` directory or a `.env` file is served straight off your web root, an attacker can download your entire source history or your application secrets with a single request. This is one of the fastest paths from "no vulnerabilities" to full compromise — and for a web3 project, a leaked deployer key or mnemonic means direct, irreversible loss. This guide covers blocking the exposure and cleaning up afterwards.
+
+---
+
+## Block the Exposed Path
+
+### Why It's Critical
+
+`/.git/config`, `/.env`, backup files and `/server-status` pages leak source, credentials and internal structure. Once served publicly they should be treated as already compromised.
+
+### Implementation Steps
+
+- [ ] Confirm the exposure (e.g. `GET /.git/config` returns repository config, or `/.env` returns `KEY=value` lines).
+- [ ] Block access to the path at the web server / CDN (deny rules for dotfiles and `.git`, disable `mod_status` exposure).
+- [ ] Remove the file or directory from the deployed web root entirely — the build/deploy process should never ship it.
+- [ ] Disable directory listing on the web server.
+
+---
+
+## Rotate Everything That Leaked
+
+### Why It's Critical
+
+If a secret was reachable on the public internet, assume it has been harvested. Blocking the path does not un-leak what was already exposed.
+
+### Implementation Steps
+
+- [ ] Rotate every credential that appeared in the exposed file — API keys, database passwords, tokens, and especially any private key or mnemonic.
+- [ ] Review access logs for signs the file was actually fetched.
+- [ ] Add exposed-file checks to your regular monitoring so a redeploy that reintroduces the file is caught.
+
+---
+
+## Notes
+
+Blocking the URL is necessary but not sufficient — rotation is the part that actually contains the incident. Prioritise any on-chain keys first.

--- a/guides/recon/secrets-exposure.md
+++ b/guides/recon/secrets-exposure.md
@@ -48,4 +48,4 @@ If a secret was reachable on the public internet, assume it has been harvested. 
 
 ## Notes
 
-Blocking the URL is necessary but not sufficient — rotation is the part that actually contains the incident. Prioritise any on-chain keys first.
+Blocking the URL is necessary but not sufficient — rotation is the part that actually contains the incident. Prioritize any on-chain keys first.

--- a/guides/recon/social-media-security.md
+++ b/guides/recon/social-media-security.md
@@ -1,0 +1,47 @@
+<!--
+id: social-media-security
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Secure Your Social Channels</h1>
+  <p><em>Protect the community an attacker will impersonate</em></p>
+</div>
+
+---
+
+## Overview
+
+For a web3 org the community lives on X, Discord and Telegram, and impersonating those channels is how most retail users get drained. Fake admin accounts, cloned servers, and "support" DMs that lead to a wallet-drainer site do their damage to your community and your reputation even when your own infrastructure is untouched. This guide covers hardening your official channels and reducing the impersonation surface.
+
+---
+
+## Harden Official Channels
+
+### Why It's Critical
+
+Impersonated social accounts and fake support are the leading cause of user fund loss in web3. The countermeasures are mostly configuration and policy, and they cost nothing.
+
+### Implementation Steps
+
+- [ ] Verify your official accounts where the platform supports it, and publish the canonical list of official channels on your own domain as a source of truth.
+- [ ] On Discord and Telegram, disable or lock down DMs and enforce a clear "admins will never DM you first" policy.
+- [ ] Restrict admin roles to a minimal set, require MFA on every admin account, and audit role assignments regularly.
+- [ ] Deploy anti-scam bots and raid protection; lock down permissions on new-member and announcement channels.
+- [ ] Brief your community regularly on how you *do* and *don't* communicate (no surprise airdrops in DMs, no "connect wallet to verify").
+
+---
+
+## Monitor for Impersonation
+
+### Implementation Steps
+
+- [ ] Connect a social-monitoring source to continuously scan for accounts and servers impersonating your brand and admins.
+- [ ] Give your community a fast way to report impersonators, and act on takedowns quickly.
+
+---
+
+## Notes
+
+Most of this is policy and configuration, not tooling. The highest-value single move is a hard, well-communicated "admins never DM first" rule — it defuses the most common scam pattern.

--- a/guides/recon/subdomain-takeover.md
+++ b/guides/recon/subdomain-takeover.md
@@ -1,0 +1,51 @@
+<!--
+id: subdomain-takeover
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Fix and Prevent Subdomain Takeovers</h1>
+  <p><em>Remove dangling DNS records before an attacker claims them</em></p>
+</div>
+
+---
+
+## Overview
+
+A subdomain takeover happens when a DNS record (usually a CNAME) points at a third-party service — GitHub Pages, Heroku, S3, a CDN — whose backing resource has been deleted, leaving the pointer dangling. An attacker can re-register that resource and serve their own content from your subdomain. For a web3 project this is catastrophic: a page on your real domain is the perfect host for a phishing or wallet-drainer site your community will trust. This guide covers fixing an active dangling record and preventing new ones.
+
+---
+
+## Remediate a Dangling Record
+
+### Why It's Critical
+
+Content served from `docs.yourdomain.com` or `status.yourdomain.com` inherits your users' trust and your domain's reputation with browsers and wallets. A takeover lets an attacker phish, steal cookies, or run a drainer under your own brand — often without you noticing until users report losses.
+
+### Implementation Steps
+
+- [ ] Identify the dangling subdomain and the service its CNAME points to (e.g. a `*.github.io` or `*.herokuapp.com` target that no longer resolves).
+- [ ] Immediately remove the dangling DNS record, OR re-claim the backing resource on the third-party service so an attacker cannot.
+- [ ] Audit **all** DNS records for other CNAMEs pointing at external services, and confirm each target still exists and is under your control.
+- [ ] Check any content-integrity or crawler monitoring for unexpected changes on the affected host.
+
+---
+
+## Prevent Future Takeovers
+
+### Why It's Critical
+
+Takeovers are almost always the result of a decommissioning process that removed the cloud resource but forgot the DNS record. A little process discipline eliminates the whole class of bug.
+
+### Implementation Steps
+
+- [ ] Make "remove the DNS record" a required step whenever you tear down a site, app, or bucket.
+- [ ] Prefer pointing records at resources you fully control; avoid CNAMEs to services that release names on deletion.
+- [ ] Run continuous subdomain / dangling-record monitoring so a new dangling pointer is flagged within hours, not months.
+
+---
+
+## Notes
+
+The dangerous signature is a CNAME to a known service whose own lookup fails (NXDOMAIN). If you see that, treat it as an active incident — an attacker may already be able to claim it.

--- a/guides/recon/tls-hardening.md
+++ b/guides/recon/tls-hardening.md
@@ -1,0 +1,51 @@
+<!--
+id: tls-hardening
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Harden TLS on Your Endpoints</h1>
+  <p><em>Valid certificates, strong keys, no legacy protocols</em></p>
+</div>
+
+---
+
+## Overview
+
+TLS is what makes the padlock mean something. An expired certificate takes your site offline behind a scary warning; an invalid chain or a legacy protocol version lets a network attacker downgrade or intercept the connection. This guide covers keeping certificates valid and automatically renewed, and configuring the server to only speak modern, secure TLS.
+
+---
+
+## Keep Certificates Valid and Automated
+
+### Why It's Critical
+
+A missed renewal is a self-inflicted outage that also trains your users to click through certificate warnings — the exact behaviour that lets a real man-in-the-middle succeed. Automation removes the human deadline entirely.
+
+### Implementation Steps
+
+- [ ] Use automated certificate issuance and renewal (ACME / Let's Encrypt, or your CA's automation).
+- [ ] Serve the **full** certificate chain, including intermediates, and ensure the certificate matches the hostname.
+- [ ] Add certificate-expiry monitoring that alerts well before the deadline as a backstop.
+- [ ] Use a 2048-bit-or-larger RSA key or a modern ECDSA (P-256) key.
+
+---
+
+## Disable Weak Protocols and Ciphers
+
+### Why It's Critical
+
+TLS 1.0 and 1.1 are deprecated and vulnerable to downgrade and cipher attacks. If your server still accepts them, an attacker on the network path can force a downgrade.
+
+### Implementation Steps
+
+- [ ] Require TLS 1.2 or higher; disable TLS 1.0 and 1.1 at the load balancer / server.
+- [ ] Prefer modern cipher suites and enable HSTS (see the web security headers guide) so browsers refuse plain HTTP.
+- [ ] Re-test your endpoint with an SSL/TLS analyser after changes and aim for an A grade.
+
+---
+
+## Notes
+
+If you terminate TLS at a CDN or load balancer, apply these settings there — that is where the public handshake actually happens.

--- a/guides/recon/tls-hardening.md
+++ b/guides/recon/tls-hardening.md
@@ -42,7 +42,7 @@ TLS 1.0 and 1.1 are deprecated and vulnerable to downgrade and cipher attacks. I
 
 - [ ] Require TLS 1.2 or higher; disable TLS 1.0 and 1.1 at the load balancer / server.
 - [ ] Prefer modern cipher suites and enable HSTS (see the web security headers guide) so browsers refuse plain HTTP.
-- [ ] Re-test your endpoint with an SSL/TLS analyser after changes and aim for an A grade.
+- [ ] Re-test your endpoint with an SSL/TLS analyzer after changes and aim for an A grade.
 
 ---
 

--- a/guides/recon/web-security-headers.md
+++ b/guides/recon/web-security-headers.md
@@ -1,0 +1,51 @@
+<!--
+id: web-security-headers
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Set Your Web Security Headers</h1>
+  <p><em>Harden the browser side of your application</em></p>
+</div>
+
+---
+
+## Overview
+
+HTTP security headers are cheap, high-leverage instructions to the browser that block whole classes of attack — protocol downgrade, script injection, clickjacking, and cookie theft. For a web3 front-end they matter more than usual, because a Content-Security-Policy is one of the strongest defences against the injected-script and malicious-dependency payloads behind most wallet-drainer attacks. This guide lists the headers to set and how.
+
+---
+
+## Send the Core Security Headers
+
+### Why It's Critical
+
+Missing headers are the difference between an injected script being blocked and it draining your users' wallets. Each header closes a specific, well-understood hole.
+
+### Implementation Steps
+
+- [ ] **Strict-Transport-Security** — `max-age=31536000; includeSubDomains` (and submit to the HSTS preload list once verified) so browsers never attempt plain HTTP.
+- [ ] **Content-Security-Policy** — restrict `script-src`, `connect-src` and `frame-ancestors` to trusted origins. Roll it out in `Content-Security-Policy-Report-Only` mode first, watch the reports, then enforce.
+- [ ] **X-Frame-Options: DENY** (or a CSP `frame-ancestors 'self'`) to prevent clickjacking of your dApp UI.
+- [ ] **X-Content-Type-Options: nosniff** on all responses.
+- [ ] **Referrer-Policy: strict-origin-when-cross-origin** so full URLs don't leak to third parties.
+
+---
+
+## Protect Your Cookies
+
+### Why It's Critical
+
+A session or auth cookie without protective attributes can be stolen by an injected script, leaked over HTTP, or ridden by a cross-site request.
+
+### Implementation Steps
+
+- [ ] Set `Secure`, `HttpOnly` and `SameSite` on session and authentication cookies.
+- [ ] Suppress software version banners (`server_tokens off` in nginx, remove `X-Powered-By`) so responses don't hand attackers a precise CVE target.
+
+---
+
+## Notes
+
+Deploy CSP in report-only mode first — a strict policy applied blind will break legitimate scripts. Use the violation reports to tune it, then switch to enforcing.


### PR DESCRIPTION
## What this adds

20 short, single-issue remediation guides under `guides/recon/`, each written to answer one question: *a scan just flagged this on my org — what exactly do I do about it?*

| Area | Guides |
| --- | --- |
| Email authentication | `email-spf`, `email-dkim`, `email-dmarc` |
| DNS & transport | `dns-hardening`, `tls-hardening`, `subdomain-takeover` |
| Web surface | `web-security-headers`, `cors-hardening`, `secrets-exposure`, `attack-surface-reduction` |
| Identity | `enforce-2fa`, `phishing-resistance`, `credential-hygiene` |
| Code & supply chain | `secret-rotation`, `dependency-management` |
| On-chain | `multisig-treasury`, `contract-verification`, `contract-security` |
| Brand & comms | `brand-impersonation-response`, `social-media-security` |

Every file carries the standard metadata block (`id` / `type: GUIDE` / `scope: ORGANIZATION`) and follows the same shape: Overview → per-control **Why It's Critical** → **Implementation Steps** checklist → Notes. `node scripts/validate.js` passes (67 guides, 67 unique IDs).

## Why the granularity

These are deliberately narrower than the existing top-level guides. `guides/dns-security.md` is the right document to read when you want to understand DNS and email authentication as a subject; `guides/recon/email-spf.md` is the right document when a scan told you your SPF record ends in `~all` and you need the fix and nothing else. The intent is one guide per finding, so a remediation link lands the reader on exactly the steps that resolve it rather than in the middle of a reference document.

That does mean some content overlaps existing guides — SPF/DKIM/DMARC/DNSSEC/CAA with `dns-security.md`, MFA with `authentication-and-mfa.md`, and multisig with `multisig-ideal-setup.md`. Happy to take this either way if maintainers prefer a different resolution:

1. keep both, as here — broad reference guides plus narrow remediation guides;
2. keep the remediation guides and have the broad guides link out to them instead of restating the detail; or
3. fold these in as sections of the existing guides and drop the separate files.

Option 1 is what's proposed, on the grounds that the two serve different moments, but this is the main review decision in the PR and worth settling before merge.

## Notes

- `guides/recon/` is a new subdirectory. If a different name reads better in this repo's vocabulary (`remediation/` is the obvious alternative), it's a rename away — no content depends on the path.
- No changes to `index.html`, requirements, or schema; the site renders requirements only, so nothing there needed updating.
