### PR TITLE
Add Supply Chain & Dependency Security guide + quality pass on all general security guides

### DIFF
--- a/guides/authentication-and-mfa.md
+++ b/guides/authentication-and-mfa.md
@@ -13,124 +13,129 @@ scope: INDIVIDUAL
 
 ## Overview
 
-Authentication and multi-factor authentication (MFA) are critical security controls that protect access to accounts and systems. This guide provides recommendations for implementing strong authentication methods based on account sensitivity levels. Phishing-resistant authentication methods should be used for high-sensitivity accounts whenever possible.
+Authentication is the control that decides whether an attacker with your password gets in. This guide helps you pick the right setup for each account based on how much damage its compromise would cause, then harden the paths attackers actually use: phishable factors, recovery flows, and long-lived sessions.
+
+The rule of thumb throughout: the more an account can move or destroy, the more it must rely on phishing-resistant factors (passkeys and hardware keys), and the harder its recovery paths must be.
 
 ---
 
 ## MFA Basics
 
-Multi-factor authentication requires authentication from multiple independent factors:
+Multi-factor authentication (MFA) combines independent factors:
 
-- **Something you know** (password, PIN, recovery secret)
-- **Something you have** (phone, laptop, hardware key)
-- **Something you are** (biometrics: fingerprint, face)
+- **Something you know** — password, PIN, recovery secret
+- **Something you have** — phone, laptop, hardware key
+- **Something you are** — biometrics (fingerprint, face)
 
-Strong authentication requires **at least 2** of these factors. For **high-sensitivity** accounts, **all 3** factors should be required where practical.
+Strong authentication requires at least two of these. For high-sensitivity accounts, require all three where practical.
+
+Two properties matter more than the factor count:
+
+- **Phishing resistance** — passkeys and hardware keys cryptographically verify the site they authenticate to, so they cannot be relayed through a fake login page. Passwords, TOTP codes, and SMS codes can.
+- **Factor independence** — two factors stored in the same place (a password and a TOTP seed in one vault) fail together. Treat them as a single factor when assessing risk.
 
 ---
 
-## Recommended Setups by Risk Level
+## Recommended Setup by Sensitivity
 
-### Low Sensitivity
-Examples: throwaway accounts, low-impact services, accounts without financial privileges.
+Classify each account by the damage its compromise could cause, then meet the bar for that tier.
+
+### Low sensitivity
+Throwaway accounts, low-impact services, accounts with no financial or reputational leverage.
 
 - [ ] **Password + TOTP (2FA)**
 
-### Medium Sensitivity
-Examples: SaaS tools, community accounts, accounts that could be used for reputation damage.
+### Medium sensitivity
+SaaS tools, community accounts, anything usable for reputation damage.
 
-- [ ] **Passkey (PIN or biometric) (2FA)**
-- [ ] OR **Password + Passkey (2FA/3FA depending on unlock method)** if the service supports requiring both
-- [ ] **Fallback:** Password + TOTP (2FA) if passkeys are not supported
+- [ ] **Passkey with PIN or biometric unlock (2FA)**
+- [ ] **Password + passkey (2FA/3FA)** where the service supports requiring both
+- [ ] **Fallback** — password + TOTP if passkeys are not supported
 
-### High Sensitivity
-Examples: primary email, GitHub/org admin, production infrastructure, exchange accounts, custody-adjacent accounts.
+### High sensitivity
+Primary email, GitHub and organization admin, production infrastructure, exchange and custody-adjacent accounts.
 
-- [ ] **Hardware key + PIN/biometric + Password (3FA)** (Example: YubiKey Bio + password)
-- [ ] OR **Password + Passkey unlocked by biometric (3FA)** (Example: password + passkey + biometric unlock)
-- [ ] **If hardware keys cannot be operationally carried reliably:**
-  - [ ] Keep the hardware key in a secure location (e.g. a safe)
-  - [ ] Use **passkey** on your phone for on-the-go access
-  - [ ] Use **TOTP** only where stronger methods are not supported
+- [ ] **Hardware key + PIN/biometric + password (3FA)** — e.g. YubiKey Bio plus a password
+- [ ] **Or password + biometric-unlocked passkey (3FA)**
+- [ ] **If a hardware key cannot be carried reliably** — keep it in a safe, use a phone passkey for on-the-go access, and fall back to TOTP only where nothing stronger is supported
 
-### Critical Sensitivity
-Examples: treasury, multisig signer accounts, domain registrar, root/admin identities, accounts that can irreversibly move funds.
+### Critical sensitivity
+Treasury, multi-sig signer accounts, domain registrar, root and admin identities — anything that can irreversibly move funds.
 
-- [ ] **Phishing-resistant authentication everywhere** (hardware key / passkey)
-- [ ] **Two independent phishing-resistant factors** where supported (primary + backup)
-- [ ] Recovery paths must be hardened (see Recovery Hardening section below)
+- [ ] **Phishing-resistant authentication everywhere** — hardware key or passkey, no phishable fallbacks
+- [ ] **Two independent phishing-resistant factors** registered where supported (primary + backup)
+- [ ] **Hardened recovery paths** — see [Recovery hardening](#recovery-hardening) below
 
 ---
 
-## Quick Decision Matrix
+## Decision Matrix
 
-Choose the strongest authentication option that can be maintained.
+Choose the strongest option you can actually maintain.
 
-| Method / Setup | Phishing Resistant? | Portability | Recovery Burden | Best Fit | Notes |
-|---|---|---|---|---|---|
-| **Hardware key + PIN/biometric + Password (3FA)** | ✅ | ⚠️ | ⚠️ | High → Critical sensitivity | Strongest common setup when operationally supportable |
-| **Hardware key + PIN/biometric (2FA)** | ✅ | ⚠️ | ⚠️ | High sensitivity | Strong security; portability, loss, and breakage are the tradeoffs |
-| **Password + Passkey (2FA/3FA)** | ✅ | ✅ | ⚠️ | High sensitivity | Adds a knowledge factor on top of phishing-resistant auth when supported |
-| **Passkey (PIN or biometric) (2FA)** | ✅ | ✅ | ⚠️ | Medium → High sensitivity | Strong default when supported; ensure multiple passkey devices |
-| **Password + TOTP (2FA)** | ❌ | ✅ | ✅ | Low → Medium sensitivity | Good fallback when passkeys/keys are not supported |
-| **Password + SMS (2FA)** | ❌ | ✅ | ✅ | Last resort | Prefer carrier protections if unavoidable |
-| **Password only** | ❌ | ✅ | ✅ | Never recommended | Baseline only; easiest to phish |
+| Setup | Phishing resistant | Portability | Recovery burden | Best fit |
+|---|---|---|---|---|
+| Hardware key + PIN/biometric + password (3FA) | ✅ | ⚠️ | ⚠️ | High → critical |
+| Hardware key + PIN/biometric (2FA) | ✅ | ⚠️ | ⚠️ | High |
+| Password + passkey (2FA/3FA) | ✅ | ✅ | ⚠️ | High |
+| Passkey with PIN/biometric (2FA) | ✅ | ✅ | ⚠️ | Medium → high |
+| Password + TOTP (2FA) | ❌ | ✅ | ✅ | Low → medium |
+| Password + SMS (2FA) | ❌ | ✅ | ✅ | Last resort |
+| Password only | ❌ | ✅ | ✅ | Never |
 
-### Decision Guidelines
-- Prefer **passkeys** or **hardware keys** for **high-sensitivity** accounts
-- Use **TOTP** when stronger methods are not supported or do not fit your workflow, but treat it as **phishable**
-- Treat your account as only as strong as its **weakest recovery path** (email/SMS/support)
-- Avoid collapsing factors: if password + TOTP seed live in the same place, treat it as a **single failure domain**
-- "Remember this device" and long-lived sessions can silently downgrade security for high-sensitivity accounts
+When choosing:
+
+- Prefer passkeys or hardware keys for anything high sensitivity or above; TOTP is a fallback and remains phishable wherever it is used
+- An account is only as strong as its weakest recovery path — email, SMS, or a persuadable support desk
+- "Remember this device" and long-lived sessions silently downgrade strong setups
 
 ---
 
 ## Implementation Checklist
 
-### Authentication Method Selection
-- [ ] Prefer **passkey** or **hardware key** if supported
-- [ ] If using a hardware key, register **two keys** (primary + backup)
-- [ ] If using passkeys, ensure you have **at least two passkey-capable devices**
-- [ ] If forced into TOTP, keep the **TOTP seed** separate from your password vault
-- [ ] Never use SMS 2FA unless there is no other option
-- [ ] If SMS must be used, protect your SIM from being swapped (number lock / takeover protection with your carrier)
+Choosing strong factors is the start; the items below close the side doors — shared blast radius, recovery flows, phone numbers, and stale sessions.
 
-### Factor Independence
-- [ ] Do not store TOTP seeds in password managers
-- [ ] If your password and your TOTP seed live in the same place, treat it as **1.5FA** at best for risk decisions
-- [ ] For high-sensitivity accounts, keep at least one factor **outside** your password vault's blast radius
+### Choosing and registering factors
 
-### Recovery Hardening
+- [ ] **Prefer a passkey or hardware key** wherever the service supports one
+- [ ] **Register two hardware keys** (primary + backup) so losing one is an inconvenience, not a lockout
+- [ ] **Keep at least two passkey-capable devices enrolled** if using passkeys
+- [ ] **Buy hardware keys directly from the manufacturer** (e.g. YubiKeys from Yubico); consider shipping to a PO box if that fits your threat model
+- [ ] **Never use SMS 2FA unless there is no other option** — and if forced into it, enable your carrier's SIM swap protections (below)
 
-💡 **Account recovery flows are often the weakest link and can bypass strong MFA. Many real-world account takeovers occur by abusing recovery flows rather than defeating MFA methods.**
+### Factor independence
 
-- [ ] Treat your **primary email** as a **high-sensitivity** account (it resets everything)
-- [ ] Remove/disable SMS recovery where possible
-- [ ] Remove old recovery emails/phones you no longer control
-- [ ] Generate recovery codes and store them securely
-- [ ] Review recovery methods at least quarterly (especially after travel, phone changes, or device upgrades)
-- [ ] SMS-based account recovery must never be enabled
+- [ ] **Do not store TOTP seeds in your password manager** — a vault compromise would yield both factors at once; keep seeds in a dedicated authenticator on a single device
+- [ ] **Keep at least one factor outside your password vault's blast radius** for every high-sensitivity account
+- [ ] **Count honestly** — if the password and TOTP seed live in the same place, treat the account as 1.5FA at best when assessing risk
 
-### Session Management
+### Recovery hardening
 
-💡 **Many services allow skipping MFA after the first login, which can silently downgrade security for high-sensitivity accounts.**
+Account recovery is the weakest link in most authentication setups — many real-world takeovers abuse recovery flows rather than defeating MFA.
 
-- [ ] Disable "remember this device" where possible on high-sensitivity accounts
-- [ ] Require re-authentication for sensitive actions (password changes, API tokens, payouts, admin changes)
-- [ ] Periodically review active sessions and revoke unrecognized sessions
-- [ ] Prefer shorter session durations on admin accounts
-- [ ] Do not stay signed in on shared or travel devices
+- [ ] **Treat your primary email as a high-sensitivity account** — it can reset nearly everything else
+- [ ] **Disable SMS-based account recovery everywhere** — it lets a SIM swapper bypass every stronger factor you've set up
+- [ ] **Remove stale recovery emails and phone numbers** you no longer control
+- [ ] **Generate recovery codes and store them securely** — printed in a safe, or in a vault separate from the password
+- [ ] **Review recovery methods quarterly**, and after travel, phone changes, or device upgrades
 
-### Hardware Security
-- [ ] Purchase hardware keys directly from the manufacturer (e.g. YubiKeys from Yubico)
-- [ ] Consider shipping to a PO box if that better fits your threat model
-- [ ] Always have a backup: second hardware key, recovery codes stored securely, and/or multiple passkey devices
+### SIM swap protection
 
----
+Your phone number is a recovery path whether you want it to be or not. Lock it down:
 
-## Common Pitfalls
+- [ ] **Set a SIM PIN** to mitigate physical SIM theft
+- [ ] **Enable carrier port-out protection**:
+  - **AT&T** — myAT&T Profile → My Linked Accounts → Manage extra security → turn on Extra security
+  - **T-Mobile** — add [Account Takeover Protection](https://www.t-mobile.com/support/plans-features/account-takeover-protection)
+  - **Verizon** — enable [Number Lock](https://myvpostpay.verizon.com/ui/acct/secure/profile/security/portsecurity)
+  - **Google Fi** — enable [Number Lock](https://support.google.com/fi/answer/15147412?hl=en#zippy=%2Cturn-on-number-lock)
+- [ ] **Register your number on Signal** even if you don't use it, so a future SIM swapper cannot impersonate you there
 
-- [ ] **Do not store TOTP seeds in password managers** - collapses factor separation and expands blast radius of vault compromise
-- [ ] **Never use SMS 2FA unless there is no other option** - if SMS must be used, protect your SIM from being swapped
-- [ ] **Always have a backup** - maintain a second hardware key, recovery codes stored securely, and/or multiple passkey devices
-- [ ] **Ensure hardware is legitimate** - purchase directly from manufacturer, consider PO box shipping
+### Session management
+
+Many services allow skipping MFA after the first login, which silently weakens everything above.
+
+- [ ] **Disable "remember this device"** on high-sensitivity accounts where possible
+- [ ] **Require re-authentication for sensitive actions** — password changes, API tokens, payouts, admin changes
+- [ ] **Review active sessions periodically** and revoke any you don't recognize
+- [ ] **Prefer short session durations** on admin accounts
+- [ ] **Never stay signed in** on shared or travel devices

--- a/guides/deployments-infra-access-control.md
+++ b/guides/deployments-infra-access-control.md
@@ -6,98 +6,77 @@ scope: ORGANIZATION
 
 <div align="center">
   <h1>Secure Deployments & Infrastructure Guide</h1>
-  <p><em>Secure CI/CD pipelines and cloud access control management </em></p>
+  <p><em>CI/CD pipelines, just-in-time access, and break-glass response</em></p>
 </div>
 
 ---
 
 ## Overview
 
-When managing cloud servers, hosting infrastructure, and deployment pipelines, it's important to carefully manage permissions to restrict privileged actions from being abused. You also want to be able to respond to critical security and availability events without these restrictions limiting you. Whether you have a dedicated infrastructure engineer or you self manage your servers, you can employ a formal approach to keep your infrastructure secure while allowing you to rapidly respond when needed.
+Deployment pipelines and cloud consoles concentrate the permissions attackers want most: the ability to ship code, change infrastructure, and reach production data. The goal of this guide is a setup where no human holds standing deployment power — routine changes flow through automation and peer-reviewed, time-boxed access grants, while a tightly controlled break-glass path preserves your ability to respond to emergencies in minutes.
+
+For the monitoring, alerting, and runbooks that back these controls, see the [Incident Response Readiness Guide](incident-response-readiness.md).
 
 ---
 
 ## Normal Operations
 
-💡 **Day-to-day infrastructure and cloud operations should be as controlled as possible to prevent and mitigate potential abuse.**
+Day-to-day infrastructure work should be as controlled as possible; the controls below make privileged abuse both difficult and visible.
 
-### Access Control Principles
+### Access control principles
 
-**Automated Actions**
-- [ ] Regular deployment permissions should be confined to only automated service accounts running on locked down cloud compute instances
-- [ ] Permission to perform deployment and infrastructure change operations must not be granted to any humans
-- [ ] If manual actions need to be taken for unique situations, provision access via peer-review JIT access requests or break-glass accounts
-- [ ] All infrastructure should be defined in Infrastructure-As-Code (IaC) definitions (e.g. Terraform) in order to support hands-off infrastructure management
+**Automation first**
 
-**Minimum Permissions**
-- [ ] DevOps operators should have the minimum possible permissions to perform their daily duties
-- [ ] Grant read-only permissions to monitor assets and assess needed changes
-- [ ] Implement least-privilege access across all infrastructure components
-- [ ] High levels of permission should only be granted on a temporary basis with enough time only to complete privileged tasks
+- [ ] **Confine deployment permissions to automated service accounts** running on locked-down cloud compute — no human accounts hold standing deployment or infrastructure-change permissions
+- [ ] **Define all infrastructure as code** (e.g. Terraform) to support hands-off infrastructure management
+- [ ] **Route exceptional manual actions through peer-reviewed JIT requests or break-glass accounts** — never ad-hoc grants
 
-**Ticket-Based Just-In-Time(JIT) Access Control**
-- [ ] **Mandatory Multi-party Approval**: All state-changing operations should require a peer reviewed and approved work order ticket via a system like Jira, Linear, Monday, etc.
-- [ ] **Reviewers**: Tickets should be configured to require at least two approvals from separate reviewers (not the implementer). Reviewers should scrutinize the requested permissions against the work to be done and ensure it is the absolute minimum required
-- [ ] **Temporary Access**: Temporary permissions should be granted to the implementer for the minimum window required to perform the work. Access should be automatically revoked after the window of time for the change has passed
-- [ ] **Scoped Permissions**: Grant only the absolute minimum set of permissions required for the specific changes
+**Minimum permissions**
 
-**JIT Platforms and Setup**
-* AWS:
-	* https://aws.amazon.com/blogs/mt/introducing-just-in-time-node-access-using-aws-systems-manager/
-	* https://aws.amazon.com/blogs/security/temporary-elevated-access-management-with-iam-identity-center/
-* GCP:
-	* https://googlecloudplatform.github.io/jit-groups/
-* Okta:
-	* https://www.okta.com/products/privileged-access/
+- [ ] **Give operators read-only access by default** — enough to monitor assets and assess needed changes
+- [ ] **Apply least privilege across every infrastructure component**
+- [ ] **Grant elevated permissions only temporarily**, with just enough time to complete the privileged task
 
-### Change Management Process
+### Just-in-time (JIT) access
 
-**Testing & Validation**
-- [ ] **Dev/Staging First**: Test all changes in development/staging environments before releasing to production against security invariants
-- [ ] **Post-Implementation Verification**: Approvers should verify changes after implementation where possible (e.g. on-chain contract deployment state matches what was expected)
-- [ ] **Documentation**: Maintain detailed records of all infrastructure changes with the ability to quickly roll back if needed
+- [ ] **Require an approved work-order ticket for every state-changing operation** — via a system like Jira, Linear, or Monday
+- [ ] **Require at least two approvals from reviewers other than the implementer** — reviewers scrutinize the requested permissions against the work to be done and cut them to the absolute minimum
+- [ ] **Grant access for the minimum window required** and revoke it automatically when the window closes
+- [ ] **Scope each grant to the specific change** — never a standing role
 
-**Scheduled Changes**
-- [ ] **Designated Hours**: Schedule tickets for implementation during specific time windows
-- [ ] **Alert System**: Set up monitoring and alerting for any changes that occur outside of those hours
+Platform setup: [AWS JIT node access](https://aws.amazon.com/blogs/mt/introducing-just-in-time-node-access-using-aws-systems-manager/) · [AWS temporary elevated access](https://aws.amazon.com/blogs/security/temporary-elevated-access-management-with-iam-identity-center/) · [GCP JIT Groups](https://googlecloudplatform.github.io/jit-groups/) · [Okta Privileged Access](https://www.okta.com/products/privileged-access/)
+
+### Change management
+
+- [ ] **Test in dev/staging first** — validate every change against security invariants before it reaches production
+- [ ] **Verify after implementation** — approvers confirm the deployed state matches what was approved (e.g. on-chain contract deployment state)
+- [ ] **Document every change** with enough detail to roll back quickly
+- [ ] **Schedule changes into designated windows**, and alert on any change that occurs outside them
 
 ---
 
 ## Emergency Response
 
-💡 **Some changes must be made in response to emergency events. The procedure for typical changes will likely be too restrictive in these cases, requiring the option to use a break-glass account to bypass these restrictions when absolutely needed.**
+Ticket-based approval is too slow for an active incident. A break-glass path bypasses it — deliberately, loudly, and with consequences designed in.
 
-### Break-Glass Account Setup
+### Break-glass account setup
 
-**Account Architecture**
-- [ ] **Individual Accounts**: Each necessary user should have individual break-glass accounts tied to their identity
-- [ ] **Service-Specific**: Each service (cloud infra, GitHub, deployment runners, etc.) requires an individual break-glass account
-- [ ] **No Bundling**: Avoid bundling via SSO or reused credentials. Each account must be isolated from other break-glass capabilities to reduce impact of usage
-- [ ] **Scoped Privileges**: Use elevated permissions but restricted where sensible (e.g., write access to existing assets without full admin privileges)
+- [ ] **One account per person** — tied to an individual identity, never shared
+- [ ] **One account per service** — cloud infrastructure, GitHub, deployment runners each get their own; no SSO bundling or credential reuse, so one account's compromise cannot unlock the rest
+- [ ] **Elevated but bounded privileges** — e.g. write access to existing assets without full admin
+- [ ] **Credentials held in a dedicated password manager vault** behind three factors: password, TOTP code or passkey, and biometric verification
 
-**Access Control**
-- [ ] **Password Manager Vault**: Control access to credentials via password manager vault
-- [ ] **Secure Storage**: Implement secure credential storage and retrieval mechanisms. Triple-factor authentication should be used (password, TOPT code or passkey, and biometric verification)
+### After every use
 
-### Post-Usage Procedures
+- [ ] **Alarm the whole team automatically** the moment break-glass credentials are accessed
+- [ ] **Require a post-mortem write-up** for every use, explicitly checking for abuse
+- [ ] **Rotate credentials and completely re-provision the account** after each use
 
-**Immediate Response**
-- [ ] **Team Alerts**: Usage of account or credential access should trigger an alarm to the whole team
-- [ ] **Post-Mortem Required**: Mandatory post-mortem write-up for any break-glass usage with checks for abuse
-- [ ] **Credential Rotation**: Rotate break-glass account credentials after each use
-- [ ] **Account Re-provisioning**: Completely tear down and re-provision accounts after each usage
+### Guardrails and trade-offs
 
-### Response Controls & Trade-offs
-
-**Automated Triggers**
-- [ ] **Alarm Integration**: Consider requiring automated triggers (e.g., uptime alarms, forced deployments, ongoing hacks) to be alarming for enabling break-glass access where feasible
-- [ ] **Monitoring Integration**: Connect break-glass access to existing monitoring and alerting systems, with their own dedicated channel or at least a high severity that cannot be neglected or suppressed
-
-**Multi-Party Controls**
-- [ ] **Two-Party Authorization**: Require multi-party review when instant response time is not absolutely needed and slight coordination delays could be tolerated 
-- [ ] **Challenge Periods**: Consider implementing access delay periods (e.g., 15-30 minutes) to allow veto by other users
-- [ ] **Escalation Procedures**: Define clear escalation paths for different emergency scenarios. All sensitive manual operations should be well justified
-
-**Incident Response Planning**
-- [ ] **Run-Books**: Establish incident response run-books for common scenarios to enable rapid response and reduce the need for privileged access
-- [ ] **Permission Modeling**: Model required permissions for each break-glass account. The accounts should be minimally permissive while still allowing recovery and response actions (e.g. rolling back to previous compute images, but not allowing new compute images be force deployed)
+- [ ] **Tie break-glass eligibility to real triggers where feasible** — an active alarm (uptime, forced deployment, ongoing attack) should normally precede its use
+- [ ] **Route break-glass alerts to a dedicated, non-suppressible channel** — or at minimum a severity level that cannot be neglected
+- [ ] **Require two-party authorization** when instant response is not absolutely needed and slight coordination delay can be tolerated
+- [ ] **Consider a short challenge period** (15–30 minutes) during which other users can veto access; every sensitive manual operation should be well justified
+- [ ] **Pre-model each account's permissions** — minimally permissive while still enabling recovery (e.g. able to roll back to a previous compute image, but not force-deploy new ones)
+- [ ] **Maintain incident runbooks for common scenarios** so responders rarely need improvised privileged access — see the [Incident Response Readiness Guide](incident-response-readiness.md)

--- a/guides/developer-security-best-practices.md
+++ b/guides/developer-security-best-practices.md
@@ -6,203 +6,134 @@ scope: INDIVIDUAL
 
 <div align="center">
   <h1>Developer Security Guide</h1>
-  <p><em>Security practices for Web3 development</em></p>
+  <p><em>Trust-level isolation for Web3 development environments</em></p>
 </div>
 
 ---
 
 ## Overview
 
-Development in Web3 presents additional security risks over traditional developer environments. Apps integrate with crypto wallets for development and testing, developers often have app or contract deployment permissions, and attackers specifically target Web3 developers and organizations to steal crypto assets.
+Web3 developers are a target class of their own. Development machines sit next to wallet extensions and deployment credentials, developers hold contract deployment permissions, and attackers deliver malware through the tools of the trade: dependencies, take-home projects, "can you check out my repo" messages, and poisoned tooling.
+
+The core defense is isolation by trust level: decide which operations are privileged, which are routine, and which are untrusted — then make sure code from one level can never touch the credentials of another. This guide covers that model and the concrete setups (dedicated devices, dev containers, browser separation) that implement it.
+
+The device and network baseline — disk encryption, screen locks, secure DNS, VPN, network and persistence monitoring — is covered in the [Personal Security Checklist](individual-security.md). This guide assumes it and focuses on what is specific to development work.
 
 ---
 
 ## Security Risks
 
-- **🦠 Malicious Code Execution**
-  - Untrusted code containing malware in development environments
-  - Compromised libraries and dependencies in trusted projects
-  - Supply chain attacks through development tools
-
-- **💻 Endpoint Compromise**
-  - General malware infection from downloads, external files, or 0-day exploits
-  - Physical device attacks and theft
-  - Network-based attacks on development machines
-
-- **🌐 Browser-Based Attacks**
-  - Browser vulnerabilities (e.g. cross-site scripting)
-  - Wallet extension attacks and vulnerabilities
-  - Session hijacking and phishing attacks
-
-- **🔑 Credential Compromise**
-  - Side-channel credential leakage
-  - Accidental credential exposure in code
-  - Overly permissive dev accounts
+- **Malicious code execution** — untrusted repos and scripts, compromised dependencies inside trusted projects, supply-chain attacks through development tools (see the [Supply Chain & Dependency Security Guide](supply-chain-dependency-security.md))
+- **Endpoint compromise** — malware from downloads and external files, 0-day exploits, network-based attacks, physical attacks and theft
+- **Browser-based attacks** — browser and wallet-extension vulnerabilities, session hijacking, phishing
+- **Credential compromise** — secrets accidentally committed to code, side-channel leakage, overly permissive dev accounts
 
 ---
 
-## Trust Level Isolation
+## Trust Levels
 
-### 🔴 **Privileged Operations**
-*Highest security requirements - dedicated secure environment*
+Classify every activity into one of three levels, and never let a lower level's code run where a higher level's credentials live.
 
-- **Wallet Operations**
-  - Transaction signing and multi-sig operations
-  - Hardware wallet interactions
-  - Transaction simulation and verification
-  - Contract deployments
+### Privileged — dedicated secure environment
 
-- **Sensitive Data Access**
-  - Internal confidential documents and information
-  - Production deployment credentials
-  - Administrative access to critical systems
+The operations that move funds or grant control:
 
-- **High Permission Sessions**
-  - Cloud platform consoles (AWS, GCP, Azure)
-  - Online banking and financial services
-  - Organization admin panels and privileged accounts
+- **Wallet operations** — transaction signing and multi-sig participation, hardware wallet interactions, transaction simulation and verification, contract deployments
+- **Sensitive data access** — production deployment credentials, internal confidential documents, administrative access to critical systems
+- **High-permission sessions** — cloud consoles (AWS, GCP, Azure), online banking and financial services, organization admin panels
 
-### 🟡 **Default Operations**
-*Standard security measures - daily work environment*
+### Default — daily work environment
 
-- **Development Work**
-  - Using pre-installed and verified development tools
-  - Working with known, trusted codebases
-  - Standard IDE and editor usage
+Standard development activity with standard precautions:
 
-- **Authenticated Browsing**
-  - Logged-in sessions for work tools
-  - Social media and communication platforms
-  - Personal browsing with saved sessions
+- **Development work** — known, trusted codebases; pre-installed and verified tools; normal IDE usage
+- **Authenticated browsing** — logged-in work tools, communication platforms, personal browsing with saved sessions
 
-### 🟠 **Untrusted Operations**
-*Maximum isolation required - disposable environment*
+### Untrusted — disposable environment
 
-- **Code Execution**
-  - Running foreign or unknown code
-  - Testing new libraries and dependencies
-  - Executing downloaded scripts or tools
+Anything that runs code or content you didn't write and haven't verified:
 
-- **File Handling**
-  - Opening external files from unknown sources
-  - Downloading and running untrusted executables
-  - Processing user-submitted content
-
-- **Risky Browsing**
-  - Opening untrusted links
-  - Temporary browsing without saved sessions
-  - Accessing potentially malicious websites
-  - Downloading and using video conference software
+- **Code execution** — foreign or unknown code, new libraries and dependencies, downloaded scripts and tools
+- **File handling** — external files from unknown sources, untrusted executables, user-submitted content
+- **Risky browsing** — untrusted links, temporary sessionless browsing, video-conference software downloads
 
 ---
 
-## Implementation Strategies
+## Implementation
 
-### 🖥️ Device Separation
+Three mechanisms enforce the trust levels in practice: separate devices, containerized execution, and separate browsers.
 
-**Dedicated Privileged Device**
-- [ ] **Separation**: Use a separate machine exclusively for privileged operations
-- [ ] **Air Gap**: Isolate from other devices and networks when possible
-- [ ] **Network Isolation**: Use separate WiFi network or cellular connection
-- [ ] **Physical Security**: No external device connections (USB drives, keyboards, etc.)
-- [ ] **VPN Usage**: Always use a VPN when traveling or on untrusted networks
+### Device separation
 
-**Development and Untrusted Environment Separation**
-- [ ] Use separate devices, OS accounts, or VMs for segregating between daily activity and untrusted operations
-- [ ] Regularly wipe untrusted environments clean
-- [ ] Assume untrusted environment is always infected with malware - do not enter any credentials for usual accounts, create dedicated accounts with minimal access when needed
+**Dedicated privileged device**
 
-### 📦 Virtualization & Containerization
+- [ ] **Use a separate machine exclusively for privileged operations**
+- [ ] **Air-gap where possible** — isolate from other devices and networks
+- [ ] **Isolate the network** — a separate WiFi network or a cellular connection
+- [ ] **Allow no external device connections** — USB drives, keyboards, and other peripherals stay off
+- [ ] **Always use a VPN** when traveling or on untrusted networks
 
-**Development Containers** *(Recommended for all code execution)*
-- [ ] **Execution**: Use dev containers for all project execution, including for trusted projects
-- [ ] **Project Isolation**: Create a separate container for each project
-- [ ] **No Persistence**: Use clean images for untrusted operations
-- [ ] **Container Methods**: Containers can be OS images in Docker, IDE-integrated project containers, or cloud-based workstations
+**Untrusted environment separation**
 
-**Virtual Machines**
-- [ ] Use VMs for untrusted operations when dedicated hardware isn't available and dev containers are not desired
-- [ ] Ensure proper VM configuration (no shared storage, network, or device access)
-- [ ] Restore VMs to clean state after each use
+- [ ] **Segregate daily activity from untrusted operations** using separate devices, OS accounts, or VMs
+- [ ] **Wipe untrusted environments regularly**
+- [ ] **Assume the untrusted environment is already infected** — never enter credentials for your usual accounts there; create dedicated minimal-access accounts when one is needed
 
-### 🌐 Browser Separation
+### Dev containers and VMs
 
-**Use a two-browser system within your default trust level:**
+Run all project code in containers — including trusted projects, since any of their dependencies can be compromised. Containers can be Docker images, IDE-integrated project containers, or cloud workstations.
 
-**🔒 Session-Based Browser** *(Trusted Operations)*
-- [ ] Use only for authenticated, trusted browsing
-- [ ] Never open links or paste URLs directly
-- [ ] Maintain logged-in sessions for work tools
-- [ ] Regular cookie and cache clearing
+- [ ] **One container per project** — never reused across projects
+- [ ] **Clean images for untrusted work** — no persistence between sessions
+- [ ] **Clone repos inside the container** — ideally a repo never touches the host machine
+- [ ] **Minimal, security-focused base images**
+- [ ] **No host network access or shared storage** for containers
+- [ ] **Keep sensitive credentials out** — untrusted projects get no API keys or deployment credentials; development credentials must be separate from production ones and encrypted at rest with a different passphrase or key
+- [ ] **Use VMs when containers don't fit** — configured with no shared storage, network, or device access, and restored to a clean snapshot after each use
 
-**🕵️ Ephemeral Browser** *(Untrusted Operations)*
-- [ ] Configure to run in private/incognito mode by default
-- [ ] Set as default browser to catch clicked links
-- [ ] No persistent cookies, cache, or history
-- [ ] Use for all temporary and untrusted browsing
+Setup guides: [VS Code / Cursor dev containers](https://code.visualstudio.com/docs/devcontainers/containers) · [JetBrains dev containers](https://www.jetbrains.com/help/idea/start-dev-container-from-welcome-screen.html)
 
-**Browser Security**
-- [ ] Keep browsers updated to latest versions
-- [ ] Avoid beta features and experimental settings
-- [ ] Use reputable, security-focused browsers for sensitive operations
+### Browser separation
 
----
+Within your default trust level, run a two-browser system:
 
-## Additional Security Tips
+**Session browser — trusted operations only**
 
-**Device Protection**
-- [ ] **Full Disk Encryption**: Enable on all devices to protect against theft
-- [ ] **Privacy Screens**: Use to prevent shoulder surfing in open spaces
-- [ ] **Biometric Authentication**: Use biometrics, passkeys, or SSO in public to avoid leaking typed credentials
-- [ ] **Linux**: Consider SELinux for advanced access controls
-- [ ] **Windows**: Enable Windows Defender Application Control or AppLocker
-- [ ] **macOS**: Ensure System Integrity Protection (SIP) is enabled
-- [ ] **Root OS Accounts**: Do not log in as root for performing daily tasks, only when absolutely necessary. Your regular account should have minimal permissions
+- [ ] **Authenticated, trusted browsing only** — never open clicked links or pasted URLs here
+- [ ] **Maintain logged-in sessions** for work tools
+- [ ] **Clear cookies and cache regularly**
 
-**Travel Security**
-- [ ] Use dedicated travel devices or wipe devices before travel
-- [ ] Create backup snapshots for easy device restoration
-- [ ] Avoid accessing sensitive accounts on untrusted networks
-- [ ] Ensure remote wipe capabilities in case of theft or seizure of device
+**Ephemeral browser — everything else**
 
-**DNS and Network Protection**
-- [ ] **Secure DNS**: Use [NextDNS](https://nextdns.io/) or [Quad9](https://quad9.net/) for malware protection
-- [ ] **VPN Usage**: Always use a VPN on untrusted networks
-- [ ] **Network Monitoring**: Use tools like [Little Snitch](https://www.obdev.at/products/littlesnitch/) (macOS), [Lulu](https://objective-see.org/products/lulu.html) (free alternative), or [Glasswire](https://www.glasswire.com/) (Windows) to actively block unknown network connections
-- [ ] **Persistence Monitoring**: Use [BlockBlock](https://objective-see.org/products/blockblock.html) to monitor common persistence locations and alert whenever a persistent component is added
+- [ ] **Private/incognito mode by default** — no persistent cookies, cache, or history
+- [ ] **Set as the system default browser** so clicked links land here, not in your session browser
+- [ ] **Use for all temporary and untrusted browsing**
 
-**Code Security**
-- [ ] **Commit Signing**: [Sign all git commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for non-repudiation in logs
-- [ ] **Encrypted Secrets**: Use a tool like [git-secret](https://sobolevn.me/git-secret/) to encrypt secrets in code repos
-- [ ] **Secret Leakage**: Use an automated scanner like [git-secrets](https://github.com/awslabs/git-secrets) in pre-commit hooks to prevent accidental leakage of unencrypted secrets
+Keep both browsers updated, avoid beta and experimental features, and give wallet extensions a third dedicated browser used only for transacting (see the [Personal Security Checklist](individual-security.md)).
 
 ---
 
-## Development Containers Setup
+## Developer-Specific Hardening
 
-Development containers completely isolate potentially risky code execution from the host machine. Even trusted projects can contain malicious dependencies, making containerized execution necessary for the security of your development environment.
+Beyond the baseline checklist, these controls matter most for people who write and ship code.
 
-### Supported IDEs
+**Operating system**
 
-**Visual Studio Code & Cursor**
-- 📖 [VS Code Dev Containers Guide](https://code.visualstudio.com/docs/devcontainers/containers)
-- 📖 [Cursor Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) (same as VS Code)
+- [ ] **Work from a non-admin account** — elevate only when genuinely necessary, never for daily tasks
+- [ ] **macOS** — keep System Integrity Protection (SIP) enabled
+- [ ] **Windows** — enable Windows Defender Application Control or AppLocker
+- [ ] **Linux** — consider SELinux for mandatory access control
 
-**JetBrains IDEs**
-- 📖 [JetBrains Dev Containers Guide](https://www.jetbrains.com/help/idea/start-dev-container-from-welcome-screen.html)
+**Travel**
 
-### Container Security Best Practices
+- [ ] **Use dedicated travel devices**, or wipe devices before travel
+- [ ] **Keep backup snapshots** for fast device restoration
+- [ ] **Avoid sensitive accounts on untrusted networks**
+- [ ] **Enable remote wipe** in case of theft or seizure
 
-**Container Configuration**
-- [ ] **One Container Per Project**: Never reuse containers across projects
-- [ ] **Appropriate Base Images**: Choose minimal, security-focused base images
-- [ ] **No Host Downloads**: Avoid downloading code outside of the container
-- [ ] **Network and Storage**: Do no allow containers to access host network and avoid shared storage devices
+**Code and secrets**
 
-**Credential Management**
-- [ ] **No Sensitive Credentials**: Avoid supplying API keys or deployment credentials to untrusted projects. Development credentials must be different from production credentials, encrypted at rest with a different passphrase/key
-- [ ] **1Password Integration**: Use [1Password SSH/Git signing](https://vinialbano.com/how-to-sign-git-commits-with-1password/#setting-up-1password-for-ssh-and-git-commit-signing) for simple secure commit signing
-
-**Container Lifecycle**
-- [ ] **Clean State**: Start each session with a clean container
-- [ ] **Initialization**: Clone repos inside of containers rather than importing them after creation (ideally, repos should never touch the host machine)
+- [ ] **Scan dependencies** for malicious, vulnerable, and risky packages with [depenemy](https://github.com/W3OSC/depenemy) — see the [Supply Chain & Dependency Security Guide](supply-chain-dependency-security.md) for the full lifecycle approach
+- [ ] **Sign all git commits** for non-repudiation in logs ([GitHub guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)); [1Password SSH/Git signing](https://vinialbano.com/how-to-sign-git-commits-with-1password/#setting-up-1password-for-ssh-and-git-commit-signing) makes this painless
+- [ ] **Encrypt secrets that must live in repos** with a tool like [git-secret](https://sobolevn.me/git-secret/)
+- [ ] **Block accidental secret leakage** with an automated pre-commit scanner like [git-secrets](https://github.com/awslabs/git-secrets)

--- a/guides/developer-security-best-practices.md
+++ b/guides/developer-security-best-practices.md
@@ -172,6 +172,7 @@ Development in Web3 presents additional security risks over traditional develope
 - [ ] **Persistence Monitoring**: Use [BlockBlock](https://objective-see.org/products/blockblock.html) to monitor common persistence locations and alert whenever a persistent component is added
 
 **Code Security**
+- [ ] **Dependency Scanning**: Scan projects for malicious, vulnerable, and risky dependencies with [depenemy](https://github.com/W3OSC/depenemy) — see the [Supply Chain & Dependency Security Guide](supply-chain-dependency-security.md) for the full lifecycle approach
 - [ ] **Commit Signing**: [Sign all git commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for non-repudiation in logs
 - [ ] **Encrypted Secrets**: Use a tool like [git-secret](https://sobolevn.me/git-secret/) to encrypt secrets in code repos
 - [ ] **Secret Leakage**: Use an automated scanner like [git-secrets](https://github.com/awslabs/git-secrets) in pre-commit hooks to prevent accidental leakage of unencrypted secrets

--- a/guides/dns-security.md
+++ b/guides/dns-security.md
@@ -5,154 +5,123 @@ scope: ORGANIZATION
 -->
 
 <div align="center">
-  <h1>DNS Security Records Guide</h1>
-  <p><em>Protect Your Domain and Email</em></p>
+  <h1>DNS Security Guide</h1>
+  <p><em>Email authentication, certificate control, and DNS integrity</em></p>
 </div>
 
 ---
 
 ## Overview
 
-DNS security records protect your domain from spoofing, phishing, and man-in-the-middle attacks. This guide tells you what to implement, why it matters, and how to do it. Whether you're a solo developer or managing enterprise infrastructure, implementing these records properly is critical for protecting your domain reputation and preventing email-based attacks.
+DNS records decide who can send email as your domain, which authorities can issue certificates for it, and whether resolvers can trust the answers they get. Without them, attackers can impersonate your domain in phishing campaigns against your own users, partners, and employees. This guide covers each record type in order of priority: what it protects against, exactly how to implement it, and whether you need it at all.
 
 ---
 
-## Email Security
+## Email Authentication
 
-**Email authentication records are the foundation of domain security. Without them, attackers can impersonate your domain and send phishing emails to your customers, partners, and employees.**
+These three records are the foundation of domain security. Without them, anyone can send email that appears to come from you.
 
 ### SPF (Sender Policy Framework)
 
-**Why It's Critical**
-Stops attackers from sending email that looks like it's from your domain. Without SPF, anyone can pretend to be you.
+**Required if you send email from your domain.**
 
-**Implementation Steps**
-- [ ] Go to your DNS provider
-- [ ] Add a TXT record at your root domain (`@`)
-- [ ] Set value to: `v=spf1 include:_spf.google.com ~all` (for Google Workspace)
-- [ ] Or: `v=spf1 include:spf.protection.outlook.com ~all` (for Microsoft 365)
- 
-**Important:** You can only have ONE SPF record. If you use multiple email services (e.g., Google + Mailchimp), combine them: `v=spf1 include:_spf.google.com 
-include:servers.mcsv.net ~all`
-                                                                                
-**Status:** Required if you send email from your domain
+SPF lists the servers allowed to send email as your domain. Without it, anyone can pretend to be you.
 
----
+- [ ] **Add a TXT record at your root domain** (`@`)
+- [ ] **Set the value for your provider** — `v=spf1 include:_spf.google.com ~all` for Google Workspace, or `v=spf1 include:spf.protection.outlook.com ~all` for Microsoft 365
+- [ ] **Keep it to ONE record** — multiple SPF records are invalid; if you use several email services (e.g. Google + Mailchimp), combine them: `v=spf1 include:_spf.google.com include:servers.mcsv.net ~all`
 
 ### DKIM (DomainKeys Identified Mail)
 
-**Why It's Critical**
-Cryptographically signs your emails so recipients know they're actually from you and haven't been tampered with.
+**Required if you send email from your domain.**
 
-**Implementation Steps**
-- [ ] Enable DKIM in your email provider (Google Workspace, Office 365, etc.)
-- [ ] Provider gives you DNS record(s) to add - the "selector" name (like google._domainkey or selector1._domainkey) comes from your provider
-- [ ] After adding the DNS record, return to your provider and click "Verify" or "Activate" to start signing emails   
+DKIM cryptographically signs outgoing mail so recipients can verify it actually came from you and wasn't tampered with in transit.
 
-**Status:** Required if you send email from your domain
-
----
+- [ ] **Enable DKIM in your email provider** (Google Workspace, Microsoft 365, etc.)
+- [ ] **Add the DNS record(s) the provider generates** — the selector name (like `google._domainkey` or `selector1._domainkey`) comes from your provider
+- [ ] **Return to the provider and click Verify/Activate** — signing doesn't start until the record is confirmed
 
 ### DMARC
 
-**Why It's Critical**
-Tells other email servers what to do when someone fails SPF or DKIM checks. This is your policy enforcement mechanism.
+**Required for all domains.**
 
-**Implementation Steps**
-- [ ] Add a TXT record at _dmarc.yourdomain.com with: v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com (make sure this email exists - you'll get daily   
-  reports)
-- [ ] Monitor reports for 1-4 weeks depending on your email patterns (longer if you send monthly invoices/newsletters)
-- [ ] Once reports show all legitimate email passes, change p=none to p=reject (or use p=quarantine as a safer middle step) 
+DMARC tells receiving servers what to do with mail that fails SPF or DKIM — it is the enforcement layer on top of both.
 
-**Why the Progression Matters**
-Starting with `p=reject` might block legitimate email if your SPF/DKIM isn't configured perfectly. The gradual approach lets you fix issues before enforcing.
+- [ ] **Add a TXT record at `_dmarc.yourdomain.com`** with `v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com` — make sure the report address exists; you'll receive daily reports
+- [ ] **Monitor reports for 1–4 weeks** (longer if you send infrequent mail like monthly invoices or newsletters) until all legitimate mail passes
+- [ ] **Then enforce** — change `p=none` to `p=reject`, using `p=quarantine` as a safer middle step if needed
 
-**Privacy Note:** Avoid using `ruf=` (forensic reports) in your DMARC record - it can expose private email content and may violate privacy regulations. Use only `rua=` for aggregate reports.                                                                                                                           
+Starting directly at `p=reject` can block legitimate email while SPF/DKIM issues remain; the staged rollout lets you find and fix them before enforcing.
 
-**Status:** Required for all domains
+**Privacy note:** avoid `ruf=` (forensic reports) in your DMARC record — forensic reports can expose private email content and may violate privacy regulations. Use only `rua=` aggregate reports.
 
 ---
 
 ## Certificate Control
 
+Who can mint valid TLS certificates for your domain is a DNS decision too.
+
 ### CAA (Certification Authority Authorization)
 
-**Why It's Important**
-Prevents rogue certificate authorities from issuing certificates for your domain. Without CAA, any CA can issue a cert for your domain.
+**Recommended for all domains serving HTTPS.**
 
-**Implementation Steps**
-- [ ] Add CAA record(s) at your root domain listing which CAs can issue certificates - format varies by DNS provider (tag: issue, value: letsencrypt.org or full format 0 issue "letsencrypt.org")
-- [ ] If using multiple CAs or want flexibility, add multiple CAA records (one per CA)
-- [ ] If using wildcard certificates (*.yourdomain.com), also add issuewild records with the same CA values 
+CAA restricts which certificate authorities may issue certificates for your domain. Without it, any CA in the world can issue one.
 
-**Status:** Recommended for all domains with HTTPS
+- [ ] **Add CAA record(s) at your root domain** naming your CA(s) — e.g. tag `issue`, value `letsencrypt.org` (full format: `0 issue "letsencrypt.org"`; syntax varies by DNS provider)
+- [ ] **Add one record per CA** if you use multiple CAs or want flexibility
+- [ ] **Add matching `issuewild` records** if you use wildcard certificates (`*.yourdomain.com`)
 
 ---
 
 ## Transport Security
 
+Email authentication proves who sent a message; transport security keeps it encrypted on the way.
+
 ### MTA-STS (Mail Transfer Agent Strict Transport Security)
 
-**Why It's Recommended**
-Forces email servers to use encrypted TLS when delivering email to you. Prevents downgrade attacks where an attacker forces email to be sent unencrypted.     
+**Recommended for business domains sending or receiving sensitive email.**
 
-**Implementation Steps**
-- [ ] Add TXT record at _mta-sts.yourdomain.com: v=STSv1; id=20260127 (increment id every time you change the policy - mail servers use this to know when to      
-refetch)
-- [ ] Create subdomain mta-sts.yourdomain.com with valid HTTPS certificate, then add policy file at /.well-known/mta-sts.txt with ALL your MX servers listed:     
+MTA-STS forces sending servers to use encrypted TLS when delivering mail to you, blocking downgrade attacks that would let mail travel unencrypted.
+
+- [ ] **Add a TXT record at `_mta-sts.yourdomain.com`** with `v=STSv1; id=20260127` — increment `id` every time you change the policy, so mail servers know to refetch it
+- [ ] **Serve a policy file** at `https://mta-sts.yourdomain.com/.well-known/mta-sts.txt` (the subdomain needs a valid HTTPS certificate):
+
 ```
 version: STSv1
 mode: testing
-mx: mail1.yourdomain.com                                                                                                                                      
-mx: mail2.yourdomain.com                                                                                                                                      
+mx: mail1.yourdomain.com
+mx: mail2.yourdomain.com
 max_age: 86400
 ```
-- [ ] After testing, change `mode: testing` to `mode: enforce` AND increment the `id` in your TXT record (e.g., `id=20260128`)
 
-**Important:** List ALL MX servers in your policy. Missing even one will cause email delivery failures from that server.
-                                        
-**Status:** Recommended for business domains sending/receiving sensitive email                                                                                                                                                                                                                                                    
+- [ ] **After testing, switch to `mode: enforce`** and increment the `id` in your TXT record (e.g. `id=20260128`)
+
+**Important:** list ALL of your MX servers in the policy — missing even one causes delivery failures from that server.
+
 ---
 
 ## DNS Integrity
 
-**Advanced DNS security features require operational maturity. Only implement these if you have dedicated resources for ongoing maintenance and monitoring.**
+These features provide the strongest guarantees but punish operational mistakes with a fully broken domain. Only adopt them if you have dedicated resources for ongoing maintenance and monitoring.
 
 ### DNSSEC
 
-**Why It's Advanced**
-Cryptographically signs your DNS records so resolvers can verify they haven't been tampered with. This prevents DNS spoofing attacks.                         
+**Required for government and financial institutions; recommended for high-value domains handling sensitive data.**
 
-**Why Not Everyone Needs It**
-DNSSEC is operationally complex. Keys expire and need rotation. If you forget to rotate keys, your entire domain stops resolving. Misconfiguration can break  
-your entire domain. Only implement if you have operational maturity.                
+DNSSEC cryptographically signs your DNS records so resolvers can verify they haven't been tampered with, defeating DNS spoofing. The trade-off is operational: keys expire and must rotate, and a missed rotation or misconfiguration takes your entire domain offline.
 
-**Implementation Steps**
-- [ ] Check if your DNS provider supports DNSSEC (not all do) - if supported, enable it (usually one-click)                                                       
-- [ ] Provider auto-generates DNSKEY and RRSIG records, then provides a DS record for you to add at your domain registrar                                         
-- [ ] Set up monitoring for key expiration (keys typically expire every 30-90 days) with alerts at least 7 days before expiration
-                              
-**Records Involved**
-- **DNSKEY:** Your public key (auto-generated by DNS provider)
-- **RRSIG:** Signatures for each DNS record (auto-generated)
-- **DS:** Hash of your DNSKEY, stored at your registrar (you add this manually)
+- [ ] **Confirm your DNS provider supports DNSSEC** (not all do), then enable it — usually one click
+- [ ] **Add the DS record at your registrar** — the provider auto-generates DNSKEY and RRSIG records and hands you the DS record to place manually
+- [ ] **Monitor key expiration** — keys typically rotate every 30–90 days; alert at least 7 days before expiry
 
-**Status:** Required for government/financial institutions. Recommended for high-value domains handling sensitive data.
-
----
+Records involved: **DNSKEY** (your public key, auto-generated), **RRSIG** (per-record signatures, auto-generated), **DS** (a hash of your DNSKEY, added manually at the registrar).
 
 ### TLSA (DANE)
 
-**Why It's Advanced**
-Binds TLS certificates to DNS records. Provides the strongest email security but requires DNSSEC first.
+**Optional — critical infrastructure or regulatory requirements only (e.g. EU government agencies).**
 
-**Why Not Everyone Needs It**
-TLSA requires DNSSEC to work. If DNSSEC breaks, TLSA breaks. **Every certificate renewal requires immediate TLSA record update** or email delivery fails. Only
-implement if you already have mature DNSSEC operations.               
- 
-**Implementation Steps**
-- [ ] **Must have DNSSEC enabled first**
-- [ ] Generate SHA-256 hash of your mail server's certificate public key (requires OpenSSL)
-- [ ] Add TLSA record at _25._tcp.mail.yourdomain.com with value: 3 1 1 <certificate-hash> (3=match cert, 1=pubkey, 1=SHA-256)
+TLSA binds your mail server's TLS certificate into DNS, providing the strongest email transport security available. It requires working DNSSEC and inherits all of its fragility — and **every certificate renewal requires an immediate TLSA record update** or email delivery fails.
 
-**Status:** Optional. Only for critical infrastructure or when required by regulation (e.g., EU government agencies).
+- [ ] **Enable DNSSEC first** — TLSA does not function without it
+- [ ] **Generate a SHA-256 hash** of your mail server's certificate public key (requires OpenSSL)
+- [ ] **Add a TLSA record at `_25._tcp.mail.yourdomain.com`** with value `3 1 1 <certificate-hash>` (3 = match certificate, 1 = public key, 1 = SHA-256)

--- a/guides/incident-response-readiness.md
+++ b/guides/incident-response-readiness.md
@@ -6,170 +6,178 @@ scope: ORGANIZATION
 
 <div align="center">
   <h1>Incident Response Readiness Guide</h1>
-  <p><em>Comprehensive incident response planning and disaster recovery procedures</em></p>
+  <p><em>Runbooks, damage control, and monitoring for when things go wrong</em></p>
 </div>
 
 ---
 
 ## Overview
 
-Effective incident response requires comprehensive preparation before disasters strike. Attackers deliberately target organizations during vulnerable moments and aim to maximize panic and confusion. A well-structured incident response plan enables rapid damage mitigation, quick business continuity restoration, and effective containment of attacker movement while engaging in asset recovery. Remember that incident response is not just about technical controls - it requires clear procedures, designated responsibilities, and regular testing to ensure effectiveness when every second counts.
+Incidents are won or lost before they happen. Attackers deliberately strike at vulnerable moments and count on panic; a prepared organization responds from a runbook while an unprepared one improvises. Readiness means three things, and this guide covers each: rehearsed procedures for the disasters you can anticipate, technical controls that contain damage fast, and monitoring that detects incidents early and cannot be silenced by the attacker.
 
 ---
 
-## Incident Response Runbook
+## Incident Response Runbooks
 
-💡 **Plan ahead with detailed response runbooks for anticipated potential disaster scenarios.**
+Write detailed runbooks for anticipated disaster scenarios before you need them. The four below are a baseline for any Web3 organization.
 
-### Core Disaster Scenarios
+### Multi-sig wallet compromise
 
-**Multi-Sig Wallet Compromise**
-- [ ] **Immediate Actions**:
-  - [ ] Temporarily freeze multi-sig contract
-  - [ ] Revoke compromised accounts immediately
-  - [ ] Re-provision new devices for compromised users (laptops, hardware wallets, phones, etc.)
-- [ ] **Recovery Procedures**:
-  - [ ] Verify integrity of remaining signers
-  - [ ] Implement emergency quorum adjustment procedures (removing compromised accounts)
-  - [ ] Coordinate with remaining trusted parties for asset recovery
+Immediate actions:
 
-**Unauthorized Code Deployment**
-- [ ] **Immediate Actions**:
-  - [ ] Bring service offline immediately
-  - [ ] Freeze automated deployments
-  - [ ] Revoke compromised accounts
-  - [ ] Roll back to last known authorized deployment
-- [ ] **Recovery Procedures**:
-  - [ ] Audit deployment logs and access patterns
-  - [ ] Verify integrity of rollback version
-  - [ ] Implement additional deployment controls to prevent future abuse
-  - [ ] Recreate affected infrastructure instances
+- [ ] **Temporarily freeze the multi-sig contract**
+- [ ] **Revoke compromised accounts** immediately
+- [ ] **Re-provision devices for affected users** — laptops, hardware wallets, phones
 
-**Endpoint Compromise/Malware Infection**
-- [ ] **Immediate Actions**:
-  - [ ] Revoke compromised user's access to all services
-  - [ ] Quarantine device and create a snapshot image for forensic analysis
-  - [ ] Wipe the device and re-provision account access
-- [ ] **Recovery Procedures**:
-  - [ ] Conduct forensic analysis of compromised device
-  - [ ] Review all actions taken by compromised account, looking for damage caused or any points of infection of other devices or cloud assets and repos
-  - [ ] Implement additional endpoint monitoring and active firewalls
+Recovery:
 
-**On-Chain Asset Theft**
-- [ ] **Immediate Actions**:
-  - [ ] Freeze contract if possible
-  - [ ] Contact [SEAL 911](https://github.com/security-alliance/seal-911) immediately
-  - [ ] Do basic forensics to determine attacker addresses
-  - [ ] Contact CEXs, DEX front-ends, and other relevant parties to blacklist attacker addresses
-- [ ] **Recovery Procedures**:
-  - [ ] Engage blockchain forensics specialists
-  - [ ] Coordinate with law enforcement
-  - [ ] Implement contract upgrade or redeployment procedures
+- [ ] **Verify the integrity of the remaining signers**
+- [ ] **Adjust the quorum through emergency procedures** to remove compromised accounts
+- [ ] **Coordinate asset recovery** with the remaining trusted parties
 
-### Response Planning Principles
+### Unauthorized code deployment
 
-**Prescriptive Procedures**
-- [ ] **Detailed Instructions**: Create step-by-step procedures that any team member can execute
-- [ ] **Clear Responsibilities**: Assign specific roles and responsibilities for each scenario
-- [ ] **Decision Trees**: Provide clear decision-making frameworks for different situations
-- [ ] **Contact Information**: Maintain updated emergency contact lists and escalation procedures
+Immediate actions:
 
-**Regular Testing & Updates**
-- [ ] **Tabletop Exercises**: Conduct regular incident response simulations
-- [ ] **Procedure Updates**: Review and update procedures based on new threats and lessons learned
-- [ ] **Team Training**: Ensure all team members understand their roles in incident response
+- [ ] **Take the service offline** and freeze automated deployments
+- [ ] **Revoke compromised accounts**
+- [ ] **Roll back** to the last known authorized deployment
+
+Recovery:
+
+- [ ] **Audit deployment logs and access patterns**
+- [ ] **Verify the integrity of the rollback version**
+- [ ] **Recreate affected infrastructure instances**
+- [ ] **Add deployment controls that would have prevented the abuse** — see the [Secure Deployments & Infrastructure Guide](deployments-infra-access-control.md)
+
+### Endpoint compromise / malware infection
+
+Immediate actions:
+
+- [ ] **Revoke the compromised user's access to all services**
+- [ ] **Quarantine the device** and create a snapshot image for forensic analysis
+- [ ] **Wipe the device and re-provision account access**
+
+Recovery:
+
+- [ ] **Analyze the forensic image**
+- [ ] **Review every action the compromised account took** — damage caused, and any spread to other devices, cloud assets, or repos
+- [ ] **Strengthen endpoint monitoring and active firewalls** based on what was missed
+
+### On-chain asset theft
+
+Immediate actions:
+
+- [ ] **Freeze the contract** if possible
+- [ ] **Contact [SEAL 911](https://github.com/security-alliance/seal-911)** immediately
+- [ ] **Identify attacker addresses** with basic forensics
+- [ ] **Notify CEXs, DEX frontends, and other relevant parties** to blacklist attacker addresses
+
+Recovery:
+
+- [ ] **Engage blockchain forensics specialists**
+- [ ] **Coordinate with law enforcement**
+- [ ] **Upgrade or redeploy contracts** as needed
+
+### Writing runbooks that work
+
+- [ ] **Prescriptive steps** — detailed enough that any team member can execute them
+- [ ] **Named roles and responsibilities** for each scenario
+- [ ] **Decision trees** for the judgment calls
+- [ ] **Current emergency contact lists** and escalation paths
+- [ ] **Regular tabletop exercises**, with procedures updated from new threats and lessons learned
+- [ ] **A trained team** — everyone knows their role before the incident, not during it
 
 ---
 
 ## Rapid Damage Control
 
-💡 **Implement technical controls that enable immediate response to contain damage and maintain business continuity.**
+These controls buy time during an incident: they contain the attacker and keep the business running while you execute a runbook.
 
-### Deployment & Access Controls
+### Deployment and access controls
 
-**Quick Deployment Rollbacks**
-- [ ] **Automated Rollback**: Implement accessible rollback mechanisms for all deployments
-- [ ] **Version Control**: Maintain comprehensive version history with verified clean states
-- [ ] **Rollback Testing**: Regularly test rollback procedures to ensure reliability
-- [ ] **Backup Deployments**: Maintain parallel deployment environments for rapid switching
+**Fast rollbacks**
 
-**Account Takeover (ATO) Response**
-- [ ] **Rapid Access Revocation**: Implement immediate access revocation capabilities (access ripcords like password manager lockouts, SSO account freezing, and consolidated access management services)
-- [ ] **Multi-Factor Reset**: Reset and re-enroll 2FA for affected accounts
-- [ ] **Privilege Escalation Controls**: Immediately remove the affected accounts' permissions from all critical systems
+- [ ] **Accessible rollback mechanisms** for every deployment
+- [ ] **Comprehensive version history** with verified clean states
+- [ ] **Regularly tested rollback procedures** — a rollback that has never been rehearsed is a hope, not a control
+- [ ] **Parallel deployment environments** maintained for rapid switching
 
-### Data Protection & Recovery
+**Account takeover response**
 
-**Non-Repudiation Controls**
-- [ ] **Signed Commits**: Require signed commits for all code changes to prevent impersonation
-- [ ] **Immutable Logs**: Implement tamper-proof, redundant logging systems that cannot be suppressed or edited without triggering alarms
-- [ ] **Action Auditing**: Keep comprehensive audit trails for all privileged actions
-- [ ] **Cryptographic Verification**: Use cryptographic signatures for critical operations where possible (e.g. using PGP keys or wallet signatures)
+- [ ] **Access ripcords** — immediate revocation capabilities such as password manager lockouts, SSO account freezing, and consolidated access management services
+- [ ] **2FA reset and re-enrollment** for affected accounts
+- [ ] **Immediate permission stripping** — remove affected accounts from all critical systems at once
 
-**Endpoint Detection and Response (EDR)**
-- [ ] **Real-Time Monitoring**: Deploy EDR agents on all organization member devices
-- [ ] **Automated Response**: Configure automated containment for detected threats (locking down the operating system, severing network and account access, etc.)
-- [ ] Solutions like [CrowdStrike](https://www.crowdstrike.com/platform/endpoint-security/), [Sentinel One](https://www.sentinelone.com/surfaces/endpoint/), or [Wazuh](https://wazuh.com/) (if you prefer OSS) offer deep insight into system behavior, flagging and preventing potential compromises as they occur
+### Non-repudiation
 
-### Backup & Recovery Systems
+- [ ] **Require signed commits** for all code changes to prevent impersonation
+- [ ] **Keep tamper-proof, redundant logs** that cannot be suppressed or edited without triggering alarms
+- [ ] **Keep comprehensive audit trails** for all privileged actions
+- [ ] **Use cryptographic signatures for critical operations** where possible — e.g. PGP keys or wallet signatures
 
-**Redundant Database Backups**
-- [ ] **Multiple Storage Media**: Use different storage media and locations (e.g. local and cloud storage)
-- [ ] **Automated Backups**: Implement automated, verified backup procedures
-- [ ] **Recovery Testing**: Regularly test backup restoration procedures
-- [ ] **Encryption**: Keep backups encrypted with a secure private/public key pair (public for encryption, private kept safe and only used to decrypt backups when needed)
+### Endpoint detection and response (EDR)
 
-**Infrastructure Redundancy**
-- [ ] **Multiple Availability Zones**: Deploy across multiple availability zones
-- [ ] **Fallback Regions**: Maintain fallback regions for disaster recovery
-- [ ] **Load Balancing**: Implement robust load balancing and failover mechanisms
-- [ ] **Geographic Distribution**: Distribute critical infrastructure geographically
+- [ ] **Deploy EDR agents on every organization member device** for real-time monitoring
+- [ ] **Configure automated containment** for detected threats — locking down the OS, severing network and account access
+- [ ] **Use proven solutions** — [CrowdStrike](https://www.crowdstrike.com/platform/endpoint-security/), [SentinelOne](https://www.sentinelone.com/surfaces/endpoint/), or [Wazuh](https://wazuh.com/) (open source) offer deep insight into system behavior, flagging and preventing compromises as they occur
+
+### Backups and redundancy
+
+**Database backups**
+
+- [ ] **Multiple storage media and locations** — e.g. local plus cloud
+- [ ] **Automated, verified backup procedures**
+- [ ] **Regularly tested restoration**
+- [ ] **Encryption with a key pair** — the public key encrypts; the private key stays locked away and is used only to restore
+
+**Infrastructure redundancy**
+
+- [ ] **Multiple availability zones** for all critical deployments
+- [ ] **Fallback regions** maintained for disaster recovery
+- [ ] **Robust load balancing and failover mechanisms**
+- [ ] **Geographic distribution** of critical infrastructure
 
 ---
 
 ## Monitoring & Alerting
 
-💡 **Establish comprehensive monitoring systems with immutable logging and redundant alerting to detect incidents quickly and securely.**
+Detection only counts if the attacker cannot turn it off. Build logging that cannot be silently edited and alerting that cannot be silently missed.
 
-### Immutable Logging Systems
+### Immutable logging
 
-**Tamper-Proof Logging**
-- [ ] **Write-Only Logs**: Configure logging systems to prevent modification or deletion of entries
-- [ ] **Cryptographic Integrity**: Use cryptographic hashes to verify log integrity (e.g. emitted logs should have an attached HMAC when stored)
-- [ ] **Real-Time Replication**: Implement real-time log replication to secure locations
+- [ ] **Append-only log storage** — entries cannot be modified or deleted once written
+- [ ] **Cryptographic integrity verification** — e.g. an HMAC attached to emitted logs when stored
+- [ ] **Real-time replication** to a secure secondary location
+- [ ] **Alerts on tampering** — any attempt to disable or modify logging pages someone
+- [ ] **Monitored log access** — reads are logged and alerted on too
+- [ ] **Retention policies** long enough for forensic analysis when needed
 
-**Log Monitoring & Protection**
-- [ ] **Alteration Alerts**: Configure alerts for any attempts to disable or modify logs
-- [ ] **Access Monitoring**: Monitor and alert on all log access attempts
-- [ ] **Retention Policies**: Implement appropriate log retention policies for forensic analysis when needed
+### Multi-channel alerting
 
-### Multi-Channel Alert Systems
+- [ ] **At least three independent alert channels**:
+  - [ ] A dedicated Telegram channel for security alerts
+  - [ ] A Discord bot posting real-time notifications to a dedicated channel
+  - [ ] Email alerts to multiple recipients
+- [ ] **PagerDuty or equivalent** for critical alerts — consider physical pagers for emergency alarms
+- [ ] **Mobile push notifications** for immediate awareness
+- [ ] **Tiered severities with automatic escalation** — on-call confirms and checks in on unacknowledged alerts, or backups and managers get paged
+- [ ] **Regular channel testing** so a dead webhook is found before the incident, not during it
+- [ ] **Tuned false-positive rates** — alarms should trip rarely enough that every one is taken seriously
 
-**Redundant Alert Delivery**
-- [ ] **Multiple Channels**: Use at least three different alert channels:
-  - [ ] **Telegram Channel**: Set up a dedicated Telegram channel for security alerts
-  - [ ] **Discord Bot**: Configure a Discord bot for real-time notifications in a dedicated channel
-  - [ ] **Email Alerts**: Implement email alerting with multiple recipients
-- [ ] **PagerDuty**: Add PagerDuty or an equivalent system for critical alerts (consider physical pagers for emergency alarms)
-- [ ] **Mobile Push**: Use mobile push notifications for immediate awareness
+### Coverage
 
-**Alert Configuration**
-- [ ] **Severity Levels**: Implement tiered alerting based on incident severity
-- [ ] **Escalation Procedures**: Configure automatic escalation for unacknowledged alerts (on-call should confirm and check in, otherwise backups and managers should be paged)
-- [ ] **Alert Testing**: Regularly test all alert channels to ensure reliability
-- [ ] **False Positive Management**: Tune alerts to minimize false positives while maintaining sensitivity (alarms should very rarely be tripped)
+**Systems**
 
-### Monitoring Coverage
+- [ ] **Infrastructure health** across all critical components
+- [ ] **Application performance and availability**
+- [ ] **Network traffic patterns** for anomalies
+- [ ] **Resource utilization** and capacity planning
 
-**System Monitoring**
-- [ ] **Infrastructure Health**: Monitor all critical infrastructure components
-- [ ] **Application Performance**: Track application performance and availability
-- [ ] **Network Traffic**: Monitor network traffic patterns for anomalies
-- [ ] **Resource Utilization**: Track resource usage and capacity planning
+**Security**
 
-**Security Monitoring**
-- [ ] **Access Patterns**: Monitor user access patterns and privilege usage
-- [ ] **Failed Authentication**: Track failed login attempts and suspicious activity
-- [ ] **Data Exfiltration**: Monitor for unusual data transfer patterns
-- [ ] **Malware Detection**: Implement real-time malware detection and alerting
-- [ ] **Anomalies in Code**: Monitor for front-end content changes and smart contract behavior and state anomalies
+- [ ] **Access patterns and privilege usage**
+- [ ] **Failed authentication attempts** and suspicious activity
+- [ ] **Data exfiltration indicators** — unusual transfer patterns
+- [ ] **Real-time malware detection**
+- [ ] **Frontend content changes and smart contract state anomalies** — Web3's highest-value tampering targets

--- a/guides/individual-security.md
+++ b/guides/individual-security.md
@@ -6,114 +6,126 @@ scope: INDIVIDUAL
 
 <div align="center">
   <h1>Personal Security Checklist</h1>
-  <p><em>A checklist guide for individuals to maximize their OpSec as part of an organization</em></p>
+  <p><em>Baseline OpSec for every member of a Web3 organization</em></p>
 </div>
 
 ---
+
 ## Overview
 
-Your personal security directly impacts your organization's security posture. Compromise of an individual can allow attackers to easily infect other organization members via trusted channels, code repos, and shared files. This checklist serves as a comprehensive list of best practices that all individuals should follow to ensure their personal security is strong to protect themselves and the organizations they are a part of.
+Your personal security posture is part of your organization's attack surface. A compromised individual gives attackers a trusted channel into everyone else — chat messages, code repos, shared files. This checklist is the baseline every member should meet; the linked guides go deeper on each area.
 
 ---
-# Work Devices
-### Device Hardware
-- [ ] Organization-related activities and work must be performed on a dedicated device (e.g. a separate laptop only for work tasks)
-- [ ] Laptops and phones should be obtained through verified supply chains:
-	- Direct from manufacturer
-	- Via a physical trusted retailer
-	- NOT from a third party or reseller
-- [ ] Devices should have biometric login options, secure boot, and support for full disk encryption
-### Device Configuration
-- [ ] Full disk encryption must be enabled on all work devices
-- [ ] All work devices must have basic antivirus software enabled (built-in OS antivirus is acceptable, but must be properly enabled without any rule exceptions)
-- [ ] Inactivity screen locks must be enabled, with a period of no more than 5 minutes before requiring password re-entry
-- [ ] OS accounts for daily usage should not have administrator privileges
-### Device Usage
-- [ ] Personal devices must never be used for work activities or have access to organization accounts
-- [ ] All security software, browsers, and operating systems must be regularly updated as soon as new releases are available that include to security fixes
-- [ ] Biometric authentication and SSO should be used in non-private spaces to prevent password leakage to cameras and onlookers
-- [ ] Privacy screens should be used when working in public spaces to prevent visual eavesdropping
-### Network Security
-- [ ] Home WiFi networks should have recommended security settings:
-	- [ ] A strong password (at least 20 characters)
-	- [ ] Router and modem updated to the latest firmware
-	- [ ] Rotated admin login credentials (not the default for the device)
-	- [ ] Have a separate network for guest devices
-	- [ ] Use WPA3/WPA2 encryption (AES, not TKIP)
-	- [ ] Disable WPS
-	- [ ] Disable remote management
-- [ ] A secure DNS provider should be configured in network settings on your devices (e.g. Cloudflare's [1.1.1.1](https://www.cloudflare.com/learning/dns/what-is-1.1.1.1/))
-- [ ] A trusted VPN profile should be configured for use when on any public Wi-Fi
-- [ ] All work devices must have active network monitoring in place (e.g. [Little Snitch](https://www.obdev.at/products/littlesnitch/), [Lulu](https://objective-see.org/products/lulu.html), or [Glasswire](https://www.glasswire.com/))
-	- [ ] Network monitoring tools must track outbound connections and block all traffic by default, unless explicitly approved
-- [ ] Persistence monitoring should be enabled (e.g. [BlockBlock](https://objective-see.org/products/blockblock.html)) to monitor common persistence locations and alert whenever a persistent component is added
-- [ ] OS network firewalls must be enabled with no rule exceptions
-# Wallets & Transactions
-### Hardware Wallets
-- [ ] Hardware wallets should be obtained through verified supply chains:
-	- Direct from manufacturer
-	- Via a physical trusted retailer
-	- NOT from a third party or reseller
-- [ ] Wallet device authenticity must be cryptographically verifiable upon receipt to ensure firmware integrity (i.e. as part of the initial set up process)
-- [ ] Hardware wallets must have a large screen capable of displaying complete transaction data
-	- [ ] Clear signing technology is recommended, but is not a silver bullet and should not replace thorough transaction scrutiny
-- [ ] Wallets should have secure PIN entry with randomized entry layouts OR biometric login
-	- [ ] PIN entry must have time-based lockouts to prevent brute force attacks
-	- [ ] PINs must be at least 6 digits long
-- [ ] Wallets should be physically secured in a safe or secret hiding place when not in use
-#### Wallet Backups
-- [ ] Seed phrases must be stored on disaster-resistant, physical media. 
-- [ ] Seed phrases must not be stored in plain text - importing them must require a passphrase, additional word, or be scrambled with a random word order; with the secret stored in a password manager
-- [ ] Private keys and seed phrases must be generated on wallet devices and must never be exported (they should never touch another device in any form - no pictures stored or backups in a password manager)
-	- [ ] Alternatively, seed phrases can be sharded (requiring N of M shards to recompose) - e.g. by using Shamir's Secret Sharing algorithm, with each shard recommended to be shared with a trusted guardian (3rd party custodian service, family members, password manager, personal physical media, etc.)
-#### Multi-sig Participation
-- [ ] Multi-sig operations must be performed on devices dedicated only to those transactions and transaction verification tools (i.e. you should have a laptop dedicated only to transacting)
-	 - [ ] Signing devices must be operated on private, authenticated networks or over trusted VPNs
-	 - [ ] Active network monitoring should be in place (e.g. Little Snitch, Lulu, or GlassWire - with default deny on all network requests and only the minimum necessary IPs to execute transactions allowed)
-	 - [ ] Persistence monitoring should be enabled (e.g. BlockBlock) to alert on any persistent component additions
-# Operations
-### Browser Security
-- [ ] Separate browsers should be used for different browsing trust levels:
-	- [ ] One browser for session-based, sensitive activities
-	- [ ] Another browser for opening links and temporary browsing
-	- [ ] Wallet extensions should only be used on a third browser dedicated only to transacting
-- [ ] Review browser extension permissions and minimize to necessary functions only. Consider removing extensions that are overly permissive (e.g. can rewrite page content, read all websites, access to file system, etc.)
-- [ ] Extensions must be obtained only from official stores (Chrome Web Store, Firefox Add-ons, Microsoft Edge Add-ons, etc.) - NEVER from alternative platforms or as user-installed extensions (i.e. manually installed from file or git repo)
-### Secure Communication
-- [ ] Externally verifiable PGP keys should be configured to sign emails so others can verify their authenticity
-	- [ ] Publish your PGP key publicly and ensure your team members have it
-- [ ] End-to-end encrypted channels should be used for confidential communications and coordination of sensitive operations (Signal is recommended)
-- [ ] Files received from outside the organization must only be opened in a secure sandbox or after being sanitized (e.g. via [Dangerzone](https://dangerzone.rocks/), [VirusTotal](https://www.virustotal.com/gui/home/upload), [Google Drive](https://support.google.com/drive/answer/141702), or on a temporary virtual machine)
-- [ ] Internally shared files must be distributed via a dedicated file sharing platform (Google Drive/Docs, Dropbox, Notion, etc.), and never sent as email or chat attachments (to prevent social engineering malware delivery vectors)
-- [ ] Shared links should always be manually navigated to or re-typed (to avoid homograph attacks)
-### Workspace Requirements
-- [ ] Sensitive operations must be performed in a dedicated workspace that is set up to prevent unauthorized visual access to screens and activities, and is isolated from common areas that others could access
-- [ ] Organizational devices and materials must be securely stored when not in use
-- [ ] Privileged operations should never be performed in public spaces
-- [ ] Computers must be locked when unattended
-# Authentication
-### Password Management
-- [ ] All passwords and secrets should be:
-	- [ ] Not reused
-	- [ ] 20-32 characters
-	- [ ] Automatically generated with the full character set (letters, numbers, and symbols)
-	- [ ] A password manager must be used (1Pass or Bitwarden recommended)
-	- [ ] Password manager master passwords should be complex, and at least 20 characters with a mix of phonetic phrases, numbers, and special characters
-		- [ ] [https://xkcd.com/936/](https://xkcd.com/936/)
-	- [ ] Organization password manager accounts should be separate from personal password manager accounts
-### Login Methods
-- [ ] SSO (Single Sign-On - e.g. Log in with Google/Github/Apple) can be used for non-sensitive accounts, but should not be enabled for highly sensitive access (financial, administrative, deployments, infrastructure, etc.)
-- [ ] 2FA must be enforced on all accounts
-	- [ ] FIDO security keys are recommended (e.g. YubiKey), but mobile authenticator apps acceptable
-	- [ ] SMS-based 2FA must never be used unless no other option is available
-	- [ ] 2FA TOPT seeds should not be stored in password managers and should only be kept on a single device
-- [ ] Passkeys are recommended as a primary login method when available
-- [ ] SMS-based account recovery must never be enabled
-### SIM Swap Mitigation
-- [ ] A SIM PIN should be set to mitigate physical theft of SIM cards
-- [ ] Additional number transfer security requirements should be configured through your phone provider:
-	- [ ] **AT&T** - Go to your myAT&T Profile and log in > My Linked Accounts > Manage extra security for your account > turn on Extra security
-	- [ ] **T-Mobile** - Add account [Takeover Protection](https://www.t-mobile.com/support/plans-features/account-takeover-protection) to your account
-	- [ ] **Verizon** - Enable [Number Lock](https://myvpostpay.verizon.com/ui/acct/secure/profile/security/portsecurity). This can be done by phone, through the app, or on [their website](https://myvpostpay.verizon.com/ui/acct/secure/profile/security/portsecurity)
-	- [ ] **Google Fi** - Enable [Number Lock](https://support.google.com/fi/answer/15147412?hl=en#zippy=%2Cturn-on-number-lock)
-- [ ] A Signal account for your phone number should be created (even if not using Signal), to prevent account impersonation via potential SIM swap attacks
+
+## Work Devices
+
+Everything below applies to any device that touches organization accounts, code, or data.
+
+### Device hardware
+
+- [ ] **Use a dedicated work device** — organization-related activity must never happen on personal devices
+- [ ] **Buy through verified supply chains** — direct from the manufacturer or a trusted physical retailer, never a third-party reseller
+- [ ] **Require modern security hardware** — biometric login, secure boot, and full disk encryption support
+
+### Device configuration
+
+- [ ] **Enable full disk encryption** on all work devices
+- [ ] **Enable antivirus** — built-in OS antivirus is acceptable, but it must be properly enabled with no rule exceptions
+- [ ] **Set an inactivity screen lock** of 5 minutes or less before password re-entry is required
+- [ ] **Use non-administrator OS accounts** for daily work
+
+### Device usage
+
+- [ ] **Never give personal devices access to organization accounts**
+- [ ] **Apply security updates promptly** — operating systems, browsers, and security software as soon as releases with security fixes are available
+- [ ] **Use biometrics or SSO in non-private spaces** so cameras and onlookers cannot capture typed passwords
+- [ ] **Use a privacy screen** when working in public spaces
+
+### Network security
+
+- [ ] **Harden your home WiFi**:
+  - [ ] Strong password (at least 20 characters) and rotated (non-default) admin credentials
+  - [ ] Router and modem updated to the latest firmware
+  - [ ] WPA3/WPA2 encryption (AES, not TKIP), with WPS disabled
+  - [ ] Remote management disabled
+  - [ ] A separate network for guest devices
+- [ ] **Use a secure DNS provider** — e.g. Cloudflare's [1.1.1.1](https://www.cloudflare.com/learning/dns/what-is-1.1.1.1/)
+- [ ] **Configure a trusted VPN** and use it on any public WiFi
+- [ ] **Run active network monitoring** — [Little Snitch](https://www.obdev.at/products/littlesnitch/), [LuLu](https://objective-see.org/products/lulu.html), or [GlassWire](https://www.glasswire.com/) — tracking outbound connections and blocking all traffic by default unless explicitly approved
+- [ ] **Run persistence monitoring** — [BlockBlock](https://objective-see.org/products/blockblock.html) alerts whenever anything installs itself to run at startup
+- [ ] **Enable the OS firewall** with no rule exceptions
+
+---
+
+## Wallets & Transactions
+
+For the full organizational picture — platform setup, quorum design, and transaction verification — see the [Multi-Sig Wallet Security Guide](multisig-ideal-setup.md).
+
+### Hardware wallets
+
+- [ ] **Buy through verified supply chains** — direct from the manufacturer or a trusted physical retailer, never a reseller
+- [ ] **Verify device authenticity cryptographically** during initial setup to confirm firmware integrity
+- [ ] **Require a screen large enough to display complete transaction data** — clear signing helps, but it is not a silver bullet and never replaces reading the transaction
+- [ ] **Require secure PIN entry** — randomized layouts or biometric login, PINs of at least 6 digits, and time-based lockouts against brute force
+- [ ] **Store wallets in a safe or hidden location** when not in use
+
+### Wallet backups
+
+- [ ] **Back up seed phrases on disaster-resistant physical media** — never digitally
+- [ ] **Never store a seed phrase in plain text** — importing it must require a passphrase, an additional word, or unscrambling a random word order, with the secret kept in a password manager
+- [ ] **Generate keys on the wallet device and never export them** — no photos, no password-manager backups; they must never touch another device in any form
+- [ ] **Alternatively, shard the seed** (e.g. Shamir's Secret Sharing, N of M shards) with shards held by trusted guardians — a custodian service, family members, separate physical media, or (since one shard alone reveals nothing) a password manager
+
+### Multi-sig participation
+
+- [ ] **Sign only on a dedicated device** used exclusively for transactions and transaction-verification tools
+- [ ] **Sign only on private, authenticated networks** or over a trusted VPN
+- [ ] **Run network and persistence monitoring on signing devices** — default-deny rules allowing only the minimum endpoints transactions require
+
+---
+
+## Operations
+
+Daily habits that keep a compromise from starting — or from spreading once it does.
+
+### Browser security
+
+- [ ] **Separate browsers by trust level** — one for session-based sensitive work, one for opening links and temporary browsing, and a third dedicated solely to wallet extensions and transacting
+- [ ] **Minimize extension permissions** — review regularly and remove anything that can rewrite page content, read all websites, or access the file system without a strong reason
+- [ ] **Install extensions only from official stores** (Chrome Web Store, Firefox Add-ons, etc.) — never sideloaded from a file or repo
+
+### Secure communication
+
+- [ ] **Sign emails with a published, externally verifiable PGP key** so recipients can verify authenticity; make sure teammates have it
+- [ ] **Use end-to-end encrypted channels** (Signal recommended) for confidential communication and coordination of sensitive operations
+- [ ] **Open external files only in a sandbox or after sanitizing** — [Dangerzone](https://dangerzone.rocks/), [VirusTotal](https://www.virustotal.com/gui/home/upload), [Google Drive](https://support.google.com/drive/answer/141702) preview, or a disposable VM
+- [ ] **Share internal files via a dedicated platform** (Google Drive/Docs, Dropbox, Notion, etc.) — never as email or chat attachments, which normalizes the exact delivery vector social-engineering malware uses
+- [ ] **Navigate to shared links manually** — re-type or manually navigate rather than clicking, to defeat homograph lookalikes
+
+### Workspace
+
+- [ ] **Perform sensitive operations in a dedicated workspace** — isolated from common areas and shielded from unauthorized visual access to screens
+- [ ] **Store organizational devices and materials securely** when not in use
+- [ ] **Never perform privileged operations in public spaces**
+- [ ] **Lock computers whenever unattended**
+
+---
+
+## Authentication
+
+Method selection by account sensitivity, recovery hardening, and session hygiene are covered in depth in the [Authentication & MFA Guide](authentication-and-mfa.md).
+
+### Password management
+
+- [ ] **Use a password manager** (1Password or Bitwarden recommended), with organization accounts separate from personal accounts
+- [ ] **Generate every password** — never reused, 20–32 characters, full character set (letters, numbers, symbols)
+- [ ] **Use a strong master password** — at least 20 characters mixing [phonetic phrases](https://xkcd.com/936/), numbers, and special characters
+
+### Login methods
+
+- [ ] **Enforce 2FA on every account** — FIDO security keys (e.g. YubiKey) recommended; mobile authenticator apps acceptable
+- [ ] **Prefer passkeys as the primary login method** where available
+- [ ] **Reserve SSO for non-sensitive accounts** — never for financial, administrative, deployment, or infrastructure access
+- [ ] **Never use SMS 2FA unless no other option exists**, and never enable SMS-based account recovery at all
+- [ ] **Keep TOTP seeds out of password managers** — a single dedicated device only
+- [ ] **Protect your phone number from SIM swaps** — set a SIM PIN and enable carrier port-out protection; see [SIM swap protection](authentication-and-mfa.md#sim-swap-protection) for carrier-specific steps

--- a/guides/multisig-ideal-setup.md
+++ b/guides/multisig-ideal-setup.md
@@ -5,210 +5,153 @@ scope: ORGANIZATION
 -->
 
 <div align="center">
-  <h1>Multi-Sig Operations and Ideal Setup Guide</h1>
-  <p><em>A comprehensive implementation of security best practices for multi-signature wallet management</em></p>
+  <h1>Multi-Sig Wallet Security Guide</h1>
+  <p><em>Platform setup, hardware wallets, transaction verification, and quorum design</em></p>
 </div>
 
 ---
 
 ## Overview
 
-Comprehensive wallet security combines multiple defensive layers to create a system that remains resilient even when facing sophisticated attacks or insider threats. The recommendations in this guide work together to establish a security framework where no single point of failure can compromise your assets. Remember that wallet security is not a one-time configuration but an ongoing process of continuous improvement and vigilance—in a landscape where attackers constantly evolve their methods, maintaining rigorous security protocols is essential for protecting high-value on-chain assets.
+Multi-sig security is defense in depth: platform choice, hardware wallets, verification discipline, isolated signing environments, and quorum design each cover for the failure of the others. Configured together, no single compromised device, person, or software component can move your assets. None of it is one-time setup — attackers constantly evolve their methods, and these layers only protect quorums that stay rigorous about maintaining them.
+
+Every signer should also meet the baseline in the [Personal Security Checklist](individual-security.md).
 
 ---
 
-## Multi-Sig & Software Wallets
+## Multi-Sig Platform & Software Wallets
 
-### Multi-Sig Platform Setup
+The software layer is the most exposed one — choose platforms and wallets that help you verify what you sign.
 
-**Trusted Multi-Sig Platform**
-- [ ] Use a trusted platform like Safe to set up and manage your multi-sig
-  - [ ] Set up wallet at [https://safe.global/wallet](https://safe.global/wallet)
-  - [ ] Safe is the gold standard for multi-sig wallet management, but any equivalent system can be used
+### Platform setup
 
-**Self-Hosted Multi-Sig UI** *(Highly Recommended)*
-- [ ] Host your own multi-sig UI for additional security
-  - [ ] Deploy from [https://github.com/safe-global/safe-wallet-monorepo/tree/dev/apps/web](https://github.com/safe-global/safe-wallet-monorepo/tree/dev/apps/web)
-  - [ ] While it should not be your final line of defense, securing the UI does protect your verification process from being compromised by supply-chain attacks
+- [ ] **Use a trusted multi-sig platform** — [Safe](https://safe.global/wallet) is the gold standard for multi-sig management, though any equivalent system can be used
+- [ ] **Self-host the multi-sig UI** (highly recommended) — deploy from the [Safe monorepo](https://github.com/safe-global/safe-wallet-monorepo/tree/dev/apps/web); it should not be your final line of defense, but securing the UI protects your verification process from frontend supply-chain attacks
 
-### Software Wallet Selection
+### Software wallet selection
 
-**Recommended Wallet Applications**
-- [ ] Review wallet security score rankings at [https://www.coinspect.com/wallets/](https://www.coinspect.com/wallets/)
+Compare wallet security scores at [coinspect.com/wallets](https://www.coinspect.com/wallets/) before choosing.
 
-**Rabby Wallet** *(Recommended)*
-- [ ] Install Rabby wallet from [https://rabby.io/](https://rabby.io/)
-  - [ ] Verify open source code
-  - [ ] Enable pre-sign security checks (e.g. new address warnings)
-  - [ ] Use built-in transaction simulation
+**[Rabby](https://rabby.io/)** (recommended, open source)
 
-**MetaMask with Security Snaps** *(Alternative)*
-- [ ] Install MetaMask from [https://metamask.io/](https://metamask.io/)
-- [ ] Install recommended security Snaps:
-  - [ ] **Wallet Guard Snap**: [https://snaps.metamask.io/snap/npm/wallet-guard-snap/](https://snaps.metamask.io/snap/npm/wallet-guard-snap/) - Good for transaction insights and security warnings
-  - [ ] **Tenderly Snap**: [https://snaps.metamask.io/snap/npm/tenderly/metamask-snap/](https://snaps.metamask.io/snap/npm/tenderly/metamask-snap/) - Allows you to easily simulate transactions before confirming them
-  - [ ] **Forta Network Snap**: [https://snaps.metamask.io/snap/npm/forta-network/metamask-snap/](https://snaps.metamask.io/snap/npm/forta-network/metamask-snap/) - Scam and malicious address detection
-  - [ ] **Web3 Antivirus Snap**: [https://snaps.metamask.io/snap/npm/web3-antivirus/web3-antivirus-snap/](https://snaps.metamask.io/snap/npm/web3-antivirus/web3-antivirus-snap/) - Security alerts on known bad addresses and assets
+- [ ] **Enable pre-sign security checks** — e.g. new-address warnings
+- [ ] **Use the built-in transaction simulation** before every signature
+
+**[MetaMask](https://metamask.io/) with security Snaps** (alternative)
+
+- [ ] **[Wallet Guard](https://snaps.metamask.io/snap/npm/wallet-guard-snap/)** — transaction insights and security warnings
+- [ ] **[Tenderly](https://snaps.metamask.io/snap/npm/tenderly/metamask-snap/)** — simulate transactions before confirming them
+- [ ] **[Forta Network](https://snaps.metamask.io/snap/npm/forta-network/metamask-snap/)** — scam and malicious address detection
+- [ ] **[Web3 Antivirus](https://snaps.metamask.io/snap/npm/web3-antivirus/web3-antivirus-snap/)** — alerts on known bad addresses and assets
 
 ---
 
 ## Hardware Wallets
 
-💡 **Hardware wallets are the cornerstone of secure asset storage and your last line of defense against attacks. All other security controls could fail and your hardware wallet would still keep you safe when used properly**
+Hardware wallets are your last line of defense: every other control in this guide could fail, and a properly used hardware wallet would still keep the keys safe.
 
-### Hardware Wallet Selection
+### Selection and purchase
 
-**Purchase Requirements**
-- [ ] **Direct Purchase**: Purchase your wallet directly from the manufacturer, do not purchase from a reseller. Use a pseudonym and ideally have it delivered to a P.O. box or secure locker.
-- [ ] **Large Screen**: Ensure your device has a large screen that supports displaying full transaction data. Wallets with clear signing technology are highly recommended
-- [ ] **Touch Screen PIN**: Use touch screen PIN entry with shuffled buttons
-- [ ] **Strong PIN**: Use at least a 6-digit PIN, but the longer the better
-- [ ] **Brand Diversification**: Consider diversifying wallet brands amongst your team to reduce risk of 0-day and supply chain vulnerabilities impacting multi-sig quorums
+- [ ] **Buy directly from the manufacturer** — never a reseller; use a pseudonym and ship to a PO box or secure locker where practical
+- [ ] **Require a large screen** that can display full transaction data; clear-signing support is highly recommended
+- [ ] **Use touch-screen PIN entry with shuffled buttons**
+- [ ] **Use at least a 6-digit PIN** — the longer the better
+- [ ] **Diversify brands across the team** so a single 0-day or supply-chain compromise cannot reach a quorum of signers
 
-**Recommended Hardware Wallets**
-- [ ] **Ledger Options**:
-  - [ ] [Ledger Stax](https://shop.ledger.com/products/ledger-stax)
-  - [ ] [Ledger Flex](https://shop.ledger.com/pages/ledger-flex)
-- [ ] **GridPlus**: [Grid Lattice1](https://gridplus.io/products/grid-lattice1)
-- [ ] **Trezor**: [Trezor Safe 5](https://trezor.io/trezor-safe-5)
+Recommended devices: [Ledger Stax](https://shop.ledger.com/products/ledger-stax) · [Ledger Flex](https://shop.ledger.com/pages/ledger-flex) · [GridPlus Lattice1](https://gridplus.io/products/grid-lattice1) · [Trezor Safe 5](https://trezor.io/trezor-safe-5)
 
-### Device Verification & Setup
+### Verification and key setup
 
-**Integrity Verification**
-- [ ] **Ledger**: Verify device integrity using [Ledger's verification guide](https://support.ledger.com/article/4404389367057-zd#h_01FPAFSEH1S9Q6B0NN21ZNKFHS)
-- [ ] **GridPlus**: Verify authenticity using [GridPlus verification guide](https://docs.gridplus.io/lattice1/lattice1-guides/how-to-verify-that-your-lattice1-is-authentic)
-- [ ] **Trezor**: Authenticate device using [Trezor authentication guide](https://trezor.io/learn/a/authenticate-trezor-safe-5)
+- [ ] **Verify device integrity on receipt** — [Ledger](https://support.ledger.com/article/4404389367057-zd#h_01FPAFSEH1S9Q6B0NN21ZNKFHS) · [GridPlus](https://docs.gridplus.io/lattice1/lattice1-guides/how-to-verify-that-your-lattice1-is-authentic) · [Trezor](https://trezor.io/learn/a/authenticate-trezor-safe-5)
+- [ ] **Generate new private keys on the device** — never import them from a computer or another device
+- [ ] **Never let keys exist digitally** — no exports, photos, or password-manager copies of private keys or seed phrases; always use 24-word seed phrases
+- [ ] **Never store seed phrases in plain text** — scramble the word order, add a 25th secret word, or require an import passphrase, with the related secret stored in a password manager
+- [ ] **Treat clear signing as an aid, not a substitute** — always fully verify transactions yourself
 
-**Key Generation & Security**
-- [ ] **Generate New Keys**: Generate new private keys on the device, do not import them from your computer or another device
-- [ ] **No Digital Storage**: Never export or store your private keys or seed phrases in any digital format, including pictures or in password managers. Always use 24-word seed phrases
-- [ ] **Seed Phrase Encryption**: Never store seed phrases in plain text. Seed phrases must be encrypted through some method. For example, seed phrases must be mixed in a randomly generated, recorded order; have a 25th secret word; or require a passphrase to be imported into a wallet - regardless of the method, the related secret value should be stored in a password manager
-- [ ] **Clear Signing Awareness**: Use Clear Signing support when available, but never rely on it alone - always fully verify transactions manually
+### Backup strategy
 
-### Private Key Backup Strategy
+A healthy quorum is itself a backup: signing wallets should serve no other purpose, and if a signer loses access, the quorum can vote to swap in a replacement. Individual seed backups are therefore optional for signers — provided the signing pool stays deep enough that losing several signers at once is still recoverable. Any wallet that controls assets outside a quorum must always have physical backups.
 
-**Backup Medium**
-- [ ] **Fireproof Metal**: Use fireproof metal as your physical seed phrase storage medium
-- [ ] **Physical Security**: Only store seed phrases backups in a secure location like a physical safe
+- [ ] **Use fireproof metal** as the physical backup medium
+- [ ] **Store backups only in a secure location** — a physical safe or equivalent
 
-**Backup Necessity**
-- [ ] **Optional Self-Recovery**: Seed phrase backups are not strictly necessary with a healthy quorum - multi-sig signing wallets should not be used for any other purpose and could be re-provisioned by existing quorum admins. In this case, it is recommended to maintain a healthy enough signing pool that loss of access to a few accounts at once could be recovered from. Either way, personal backup methods for admins are required to maintain access to on-chain assets in the event of loss of access to hardware wallets
-- [ ] **Quorum Social Recovery**: If access to wallet is lost, the quorum can vote to edit members to replace the inaccessible wallet
+Advanced options:
 
-**Advanced Backup Options**
-- [ ] **Key Splitting**: Split the key into multiple shards and securely distribute them
-  - [ ] Use [Shamir's Secret Sharing algorithm](https://en.wikipedia.org/wiki/Shamir%27s_secret_sharing) for N of M key shards
-  - [ ] Consider using this [Shamir Secret Sharing implementation](https://github.com/privy-io/shamir-secret-sharing)
-- [ ] **Multi-Share Backups**: Use device-supported multi-share backups where available
-  - [ ] [Trezor Multi-Share Backup](https://trezor.io/learn/a/multi-share-backup-on-trezor)
-- [ ] **Secure Distribution**: Give shards to trusted family members, put in bank safe deposit boxes, and keep hidden around your house
+- [ ] **Shard the seed** with [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_secret_sharing) (N of M shards) — see this [open-source implementation](https://github.com/privy-io/shamir-secret-sharing)
+- [ ] **Use device-native multi-share backups** where available — e.g. [Trezor Multi-Share Backup](https://trezor.io/learn/a/multi-share-backup-on-trezor)
+- [ ] **Distribute shards across trust boundaries** — trusted family members, bank safe-deposit boxes, hidden physical locations
 
 ---
 
 ## Contract-Level Controls
 
-### Smart Contract Security
+On-chain controls keep working even when every off-chain layer is compromised.
 
-**Invariant Checks**
-- [ ] **Design Invariants**: Design contracts to enforce invariants and expected state changes such as token balance changes, ownership and administration, and proxy implementation addresses
-- [ ] **Automated Reversion**: Ensure contracts automatically revert transactions if any invariant is violated
-
-### Time-Lock Implementation
-
-**Challenge Periods**
-- [ ] **Enforce Time-Locks**: Incorporate challenge periods into your transaction execution process
-- [ ] **Veto Quorum**: Establish a smaller veto group separate from the confirmation quorum to review and confirm transaction legitimacy
-- [ ] **Delayed Execution**: Implement time-locks to prevent immediate execution of suspicious transactions
-- [ ] **Zodiac Delay Modifier**: Consider using [Zodiac Modifier Delay](https://github.com/gnosisguild/zodiac-modifier-delay/tree/main) or equivalent for implementing on-chain time-lock transaction delays to Safe wallets
+- [ ] **Enforce invariants in the contracts themselves** — expected token balance changes, ownership and administration, proxy implementation addresses — with automatic reversion when any invariant is violated
+- [ ] **Add a challenge period before execution** so suspicious transactions can be caught in flight
+- [ ] **Establish a veto quorum** — a smaller group, separate from the confirmation quorum, that reviews pending transactions and can block them
+- [ ] **Use [Zodiac Modifier Delay](https://github.com/gnosisguild/zodiac-modifier-delay/tree/main)** or equivalent for on-chain time-locked delays on Safe wallets
 
 ---
 
-## Transaction Review Process
+## Transaction Verification
 
-💡 **Implement strict verification processes to prevent human error and detect compromised software or transactions. Verification processes break down over time if they are not well defined and teams are not constantly proactive and vigilant**
+Verification discipline decays: processes break down over time unless they are well defined and teams stay deliberately vigilant. The tools below make rigorous verification cheap enough to sustain.
 
-### Verification Tools & Simulations
+### Verify what you sign
 
-**Transaction Hash Verification**
-- [ ] **Safe TX Hashes Util**: Use [Safe TX Hashes Util](https://github.com/pcaversaccio/safe-tx-hashes-util) to generate expected transaction hashes
-  - [ ] Compare generated hashes to hashes displayed on your hardware wallets
-  - [ ] Consider the [Cyfrin fork](https://github.com/Cyfrin/safe-tx-hashes) for additional support without relying on Safe API
+- [ ] **Compute expected transaction hashes independently** with [Safe TX Hashes Util](https://github.com/pcaversaccio/safe-tx-hashes-util) — or the [Cyfrin fork](https://github.com/Cyfrin/safe-tx-hashes), which works without relying on the Safe API — and compare against what your hardware wallet displays
+- [ ] **Decode calldata into human-readable form** with the [Swiss Knife decoder](https://calldata.swiss-knife.xyz/decoder)
+- [ ] **Monitor the Safe for suspicious activity** — [Safe Watcher](https://github.com/Gearbox-protocol/safe-watcher) or equivalent, connected to Telegram and watching especially for unexpected `delegateCall` transactions
+- [ ] **Firewall signing machines to known-good domains** using the [DeFi DNS whitelist](https://github.com/0xKoda/defi-dns-whitelist/tree/main)
+- [ ] **Run network and persistence monitoring on signing machines** — [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) or [LuLu](https://objective-see.org/products/lulu.html) (macOS), [GlassWire](https://www.glasswire.com/) (Windows), plus [BlockBlock](https://objective-see.org/products/blockblock.html) to alert on anything installing persistence
 
-**Monitoring & Analysis Tools**
-- [ ] **Safe Watcher**: Implement [Gearbox Safe Watcher](https://github.com/Gearbox-protocol/safe-watcher) or equivalent for monitoring and alerts
-  - [ ] Connect to Telegram for notifications
-  - [ ] Monitor for suspicious delegateCall transactions
-- [ ] **DNS Whitelist**: Use [DeFi DNS Whitelist](https://github.com/0xKoda/defi-dns-whitelist/tree/main) as a firewall for dedicated signing machines
-- [ ] **Calldata Decoder**: Use [Swiss Knife Decoder](https://calldata.swiss-knife.xyz/decoder) to make transaction call data more human-readable
+### Multi-channel confirmation
 
-**Network Monitoring**
-- [ ] **Little Snitch**: Install [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) for active firewall and network monitoring
-- [ ] **Lulu**: Use [Lulu](https://objective-see.org/products/lulu.html) as a free, open source alternative to Little Snitch
-- [ ] **BlockBlock**: Install [BlockBlock](https://objective-see.org/products/blockblock.html) to monitor common persistence locations and alert whenever a persistent component is added
-- [ ] **Glasswire**: [Glasswire](https://www.glasswire.com/) can be used for Windows machines
-
-### Multi-Channel Verification
-
-**Redundant Confirmation Channels**
-- [ ] **Never Rely on Single Device**: Never rely solely on the signing machine for confirmation
-- [ ] **Two Additional Devices**: Validate transaction details on at least two additional devices to compare against wallet transaction details. It is recommended to include a mobile device as one of these
-- [ ] **Independent Verification**: Ensure multi-channel approach provides independent verification even if one device is compromised
+- [ ] **Never rely on the signing machine alone** to tell you the truth about a transaction
+- [ ] **Validate transaction details on at least two additional devices** — a mobile device is recommended as one of them
+- [ ] **Keep the channels independent** so one compromised device cannot forge consensus
 
 ---
 
-## Device Segregation & Hardening
+## Signing Environment
 
-💡 **Isolate wallet management environments to reduce risk and prevent cross-contamination.**
+Isolate wallet management from everything else you do. Three tiers, strongest first:
 
-### Air-Gapped Machine Options
+**Air-gapped machine** (highest security)
 
-**Complete Network Isolation** *(Highest Security)*
-- [ ] **Physical Isolation**: Physically remove or disable the network interface
-- [ ] **Data Transfer Methods**: Use USB drives (with strict auto-run restrictions) or QR codes to transfer transaction data
-- [ ] **USB Precautions**: Exercise additional caution when using USBs for data transfer
+- [ ] **Physically remove or disable the network interface**
+- [ ] **Move transaction data by QR code or USB** — with strict auto-run restrictions and extra caution on any USB use
 
-**Restricted Network Access** *(Balanced Approach)*
-- [ ] **Firewall Rules**: Allow network connectivity but enforce strict firewall rules. Active network monitoring tools can be used to easily accomplish this
-- [ ] **Transaction-Only Traffic**: Permit only transaction-related traffic
-- [ ] **Usability Balance**: Provides balance between usability and security
+**Restricted-network machine** (balanced)
 
-**Dedicated Device** *(Minimum Requirement)*
-- [ ] **Single Purpose**: Use a dedicated laptop exclusively for crypto transactions
-- [ ] **No Other Activities**: Avoid using device for any other purpose
-- [ ] **Disciplined Usage**: Maintain strict discipline to avoid contamination from other activities
+- [ ] **Enforce strict firewall rules** permitting only transaction-related traffic — active network monitoring tools make this straightforward to maintain
 
-### Advanced OS-Level Controls
+**Dedicated machine** (minimum requirement)
 
-**Security-Hardened Operating Systems** *(For Advanced Users)*
-- [ ] **SELinux Implementation**: Consider employing SELinux or similar tools for advanced security configurations
-- [ ] **File System Restrictions**: Restrict file system access and inter-process communications
+- [ ] **One laptop, used exclusively for crypto transactions** — no other activities, ever; the discipline is the control
+
+For advanced users, SELinux or similar mandatory access controls can further restrict file system access and inter-process communication on signing machines.
 
 ---
 
-## Wallet & Quorum Diversity
+## Wallet & Quorum Design
 
-💡 **Diversify your wallet infrastructure and carefully select your multi-signature quorum to minimize single points of failure.**
+Minimize single points of failure in both where assets sit and who can move them.
 
-### Wallet Separation Strategy
+### Wallet separation
 
-**Cold vs Hot Wallet Separation**
-- [ ] **Separate Storage Types**: Keep long-term storage (cold wallets) distinct from day-to-day transaction signing (hot wallets)
-- [ ] **Split Cold Wallets**: Split up cold wallet assets into multiple smaller wallets to prevent total loss in a single transaction in the event of an attack. At least 3 equally funded cold wallets is recommended
+- [ ] **Separate cold storage from hot signing wallets** — long-term holdings never share keys with day-to-day transacting
+- [ ] **Split cold assets across at least 3 equally funded wallets** so no single attack can take everything in one transaction
 
-### Quorum Selection
+### Quorum selection
 
-**Quantity and Expertise Requirements**
-- [ ] **Technical Signers**: Include a high number of competent, well-vetted technical signers that will understand full transaction details and effects in your signing quorum
-- [ ] **Optimal Quorum Size**: Implement a transaction approval threshold of 3 to 5 signers from a pool of no more than double that amount as potential signers. More signers is not always better, ensure all signers are highly trusted and secure. Have as high of a signing threshold as you can tolerate
+- [ ] **Favor competent, well-vetted technical signers** who will understand full transaction details and effects
+- [ ] **Use a 3-to-5 signature threshold** drawn from a pool of no more than double that — more signers is not automatically better; every signer must be highly trusted and secure. Set the threshold as high as you can tolerate
+- [ ] **Diversify signer backgrounds** — developers, founders, and other trusted roles, plus external parties such as security auditors or trusted advisors
+- [ ] **Distribute signers across different hardware, networks, and organizations**
 
-**Diversity Requirements**
-- [ ] **Background Diversity**: Choose signers from varying organization roles. Include developers, founders, and other trusted roles
-- [ ] **External Parties**: Include external parties such as security auditors or trusted advisors
-- [ ] **Distributed Signers**: Ensure signers are distributed across different hardware, networks, and organizations
+### Custody options
 
-### Custodianship Considerations
-
-**Managed Custody Services** *(Optional)*
-- [ ] **Third-Party Options**: Self-management is not a hard requirement. Consider using a custody service with a company whose business model focuses on securely managing on-chain assets (e.g. Circle, CEXs like Coinbase or Kraken, [MPC Vault](https://mpcvault.com/), etc.)
-- [ ] **Mixed Management**: Consider a combination of in-house hot wallet management and external custodian services for cold storage
-- [ ] **Risk Diversification**: Use diversification of management methods to reduce overall risk
+- [ ] **Consider professional custody** — self-management is not a hard requirement; custody services whose business is securing on-chain assets (Circle, CEXs like Coinbase or Kraken, [MPC Vault](https://mpcvault.com/)) are a legitimate option
+- [ ] **Consider mixing models** — in-house hot wallet management with external custody for cold storage diversifies management risk

--- a/guides/supply-chain-dependency-security.md
+++ b/guides/supply-chain-dependency-security.md
@@ -23,26 +23,26 @@ This guide covers how to vet, pin, update, monitor, and respond to dependencies 
 
 ## Security Risks
 
-- **🎣 Malicious Packages by Design**
+- **Malicious packages by design**
   - Typosquatting: names one character away from popular packages (`ethes`, `web3.js` vs `web3js`)
   - Dependency confusion: public packages published under your internal/private package names, winning resolution over the real ones
   - Starter kits, "airdrop tools," and job-interview "take-home projects" seeded with credential stealers
 
-- **📦 Compromised Legitimate Packages**
+- **Compromised legitimate packages**
   - Maintainer account takeover via phishing or credential stuffing, followed by a malicious release of a trusted package
   - Ownership transfer to a "helpful new maintainer" who later ships a payload
   - Abandoned or archived projects silently adopted by attackers
 
-- **⚙️ Install-Time Code Execution**
+- **Install-time code execution**
   - npm `preinstall`/`postinstall` scripts run arbitrary code the moment you (or CI) run `npm install` — before you ever import the package
   - Build-time code in setup scripts and build plugins with the same effect in other ecosystems
 
-- **🔄 Update-Channel Attacks**
+- **Update-channel attacks**
   - Loose version ranges (`^`, `~`, `>=`, `*`) automatically pull the next published version — the exact window a hijacked release exploits
   - Lockfile tampering in pull requests, hiding a swapped package or resolved URL inside thousands of lockfile diff lines
   - Auto-merged update PRs shipping a compromised version to production with no human review
 
-- **🏗️ Build, CI, and User Exposure**
+- **Build, CI, and user exposure**
   - Dependencies execute inside CI with access to workflow secrets, signing keys, and deploy credentials
   - Frontend dependencies ship directly to users' browsers — a compromised UI package becomes a wallet drainer
   - Compromised developer machines (see the [Developer Security Guide](developer-security-best-practices.md)) become a path to publishing malicious versions of *your own* packages
@@ -53,60 +53,60 @@ This guide covers how to vet, pin, update, monitor, and respond to dependencies 
 
 Treat every dependency as a vendor relationship with distinct decisions at each stage: **intake → pinning → updating → monitoring → removal**.
 
-### 🔍 Intake: Vetting New Dependencies
+### Intake: vetting new dependencies
 
 Every new dependency is a permanent expansion of your attack surface. Vet before the first install:
 
-- [ ] **Necessity First**: Prefer the standard library, existing dependencies, or a small amount of first-party code over adding a new package for trivial functionality
-- [ ] **Package Age**: Require versions at least 6 months old with balanced usage metrics — brand-new packages and brand-new versions carry the highest risk
-- [ ] **Health Signals**: Check weekly downloads, contributor count, maintenance activity, and whether a linked source repository exists and is not archived
-- [ ] **Name Verification**: Compare the package name character-by-character against official documentation in a monospace font; never install a name from a chat message, search result, or LLM output without verifying it
-- [ ] **Install Scripts**: Check for `preinstall`/`postinstall` scripts (`npm pkg get scripts` on the tarball, or a depenemy scan) and treat their presence as requiring justification
-- [ ] **Source Review**: Skim the actual published artifact (not just the GitHub repo — they can differ) for obfuscated code, network calls, or environment variable access that doesn't match the package's purpose
-- [ ] **Scan Before Adding**: Run [depenemy](https://github.com/W3OSC/depenemy) against the change introducing the dependency so reputation and supply chain checks run before merge
-- [ ] **Sandbox First Contact**: Perform first installs and evaluation of unfamiliar packages in an isolated environment, never on a machine with wallet or production access
+- [ ] **Necessity first** — prefer the standard library, existing dependencies, or a small amount of first-party code over adding a new package for trivial functionality
+- [ ] **Package age** — require versions at least 6 months old with balanced usage metrics; brand-new packages and brand-new versions carry the highest risk
+- [ ] **Health signals** — check weekly downloads, contributor count, maintenance activity, and whether a linked source repository exists and is not archived
+- [ ] **Name verification** — compare the package name character-by-character against official documentation in a monospace font; never install a name from a chat message, search result, or LLM output without verifying it
+- [ ] **Install scripts** — check for `preinstall`/`postinstall` scripts (`npm pkg get scripts` on the tarball, or a depenemy scan) and treat their presence as requiring justification
+- [ ] **Source review** — skim the actual published artifact (not just the GitHub repo — they can differ) for obfuscated code, network calls, or environment variable access that doesn't match the package's purpose
+- [ ] **Scan before adding** — run [depenemy](https://github.com/W3OSC/depenemy) against the change introducing the dependency so reputation and supply chain checks run before merge
+- [ ] **Sandbox first contact** — perform first installs and evaluation of unfamiliar packages in an isolated environment, never on a machine with wallet or production access
 
-### 📌 Pinning & Lockfiles
+### Pinning and lockfiles
 
 Make every install reproducible and every change to third-party code visible in review:
 
-- [ ] **Exact Pins**: Pin direct dependencies to exact versions — no `^`, `~`, `>=`, or `*` ranges in manifests
-- [ ] **Lockfiles Committed**: Commit `package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`, `Cargo.lock`, `uv.lock`/`poetry.lock` (or hash-pinned requirements) to version control for every project, including internal tools
-- [ ] **Lockfile-Only Installs in CI**: Use `npm ci` (not `npm install`), `pip install --require-hashes`, `cargo build --locked`, etc., so CI can never resolve versions the lockfile doesn't contain
-- [ ] **Disable Install Scripts by Default**: Set `ignore-scripts=true` in `.npmrc` (npm/yarn/pnpm) and explicitly allowlist the few packages that genuinely need build scripts (pnpm supports this natively)
-- [ ] **Review Lockfile Diffs**: Treat lockfile changes as code changes; reviewers must check that resolved packages, versions, and registry URLs match the intended update
-- [ ] **Pin Transitives When Needed**: Use `overrides` (npm), `resolutions` (yarn), or equivalent to force known-good versions of vulnerable or suspicious transitive dependencies
+- [ ] **Exact pins** — pin direct dependencies to exact versions; no `^`, `~`, `>=`, or `*` ranges in manifests
+- [ ] **Lockfiles committed** — commit `package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`, `Cargo.lock`, `uv.lock`/`poetry.lock` (or hash-pinned requirements) to version control for every project, including internal tools
+- [ ] **Lockfile-only installs in CI** — use `npm ci` (not `npm install`), `pip install --require-hashes`, `cargo build --locked`, etc., so CI can never resolve versions the lockfile doesn't contain
+- [ ] **Disable install scripts by default** — set `ignore-scripts=true` in `.npmrc` (npm/yarn/pnpm) and explicitly allowlist the few packages that genuinely need build scripts (pnpm supports this natively)
+- [ ] **Review lockfile diffs** — treat lockfile changes as code changes; reviewers must check that resolved packages, versions, and registry URLs match the intended update
+- [ ] **Pin transitives when needed** — use `overrides` (npm), `resolutions` (yarn), or equivalent to force known-good versions of vulnerable or suspicious transitive dependencies
 
-### 🔄 Updating Deliberately
+### Updating deliberately
 
-Staying outdated is a risk; updating blindly is a bigger one. Updates should be **deliberate, delayed, and reviewed**:
+Staying outdated is a risk; updating blindly is a bigger one. Updates should be deliberate, delayed, and reviewed:
 
-- [ ] **Release Cooldown**: Never adopt a version less than 7 days old — most malicious releases are detected and pulled within days of publication. Enforce this with a configured cooldown policy (Dependabot `cooldown`, Renovate `minimumReleaseAge`, or pnpm `minimumReleaseAge`) rather than convention
-- [ ] **Human Review Required**: Every dependency update lands via a pull request reviewed by a human — never auto-merge dependency updates, including "patch-only" ones
-- [ ] **Read Before Merging**: For security-sensitive or widely-used packages, review the changelog and the actual diff between published versions before approving
-- [ ] **Prioritize by Exposure**: Fast-track updates that fix vulnerabilities exploitable in your usage; batch routine version bumps on a regular cadence
-- [ ] **Rebuild and Test in Isolation**: Run updated dependencies through CI and isolated environments before they reach machines with production or signing access
+- [ ] **Release cooldown** — never adopt a version less than 7 days old; most malicious releases are detected and pulled within days of publication. Enforce this with a configured cooldown policy (Dependabot `cooldown`, Renovate `minimumReleaseAge`, or pnpm `minimumReleaseAge`) rather than convention
+- [ ] **Human review required** — every dependency update lands via a pull request reviewed by a human; never auto-merge dependency updates, including "patch-only" ones
+- [ ] **Read before merging** — for security-sensitive or widely-used packages, review the changelog and the actual diff between published versions before approving
+- [ ] **Prioritize by exposure** — fast-track updates that fix vulnerabilities exploitable in your usage; batch routine version bumps on a regular cadence
+- [ ] **Rebuild and test in isolation** — run updated dependencies through CI and isolated environments before they reach machines with production or signing access
 
-### 📡 Continuous Monitoring
+### Continuous monitoring
 
 New vulnerabilities and newly-flagged malicious packages affect dependencies you already pinned:
 
-- [ ] **Dependabot Alerts**: Enable the dependency graph and Dependabot alerts on all repositories (see the [GitHub configuration guide](<account configurations/organizations/devops-accounts/github.md>)) so known-vulnerable versions surface automatically
-- [ ] **Scheduled Scans**: Run depenemy on a schedule (not just on PRs) so newly-published advisories and reputation changes against existing pins are caught
-- [ ] **Alert Routing**: Route dependency alerts to a channel the team actually triages, with an owner and an SLA — an ignored alert stream is equivalent to no alerts
-- [ ] **Dependency Inventory**: Maintain visibility into what you depend on across all repos (GitHub dependency graph, or SBOM generation for release artifacts) so "are we affected?" takes minutes, not days
+- [ ] **Dependabot alerts** — enable the dependency graph and Dependabot alerts on all repositories (see the [GitHub configuration guide](<account configurations/organizations/devops-accounts/github.md>)) so known-vulnerable versions surface automatically
+- [ ] **Scheduled scans** — run depenemy on a schedule (not just on PRs) so newly-published advisories and reputation changes against existing pins are caught
+- [ ] **Alert routing** — route dependency alerts to a channel the team actually triages, with an owner and an SLA; an ignored alert stream is equivalent to no alerts
+- [ ] **Dependency inventory** — maintain visibility into what you depend on across all repos (GitHub dependency graph, or SBOM generation for release artifacts) so "are we affected?" takes minutes, not days
 
-### 🗑️ Removal & Pruning
+### Removal and pruning
 
-- [ ] **Regular Pruning**: Periodically remove unused dependencies (`depcheck`, `cargo machete`, etc.) — every removed package is attack surface gone
-- [ ] **Replace the Abandoned**: Migrate away from deprecated, archived, or single-maintainer packages in critical paths before they become someone else's takeover target
-- [ ] **Full Removal**: When removing a package, confirm it also leaves the lockfile and that no scripts or CI steps still reference it
+- [ ] **Regular pruning** — periodically remove unused dependencies (`depcheck`, `cargo machete`, etc.); every removed package is attack surface gone
+- [ ] **Replace the abandoned** — migrate away from deprecated, archived, or single-maintainer packages in critical paths before they become someone else's takeover target
+- [ ] **Full removal** — when removing a package, confirm it also leaves the lockfile and that no scripts or CI steps still reference it
 
 ---
 
 ## Recommended Tooling
 
-### 🛡️ Depenemy
+### Depenemy
 
 [Depenemy](https://github.com/W3OSC/depenemy) is W3OSC's open-source dependency scanner, built specifically around the supply chain threat model described in this guide. It scans npm/Node.js, Python, Rust, and Solidity (Foundry/Hardhat) projects for three categories of findings:
 
@@ -163,49 +163,52 @@ repos:
 
 Thresholds, per-rule severities, and ignores are configured in a `.depenemy.yml` at the repository root, so teams can tune checks (e.g. for internal packages) without disabling scanning.
 
-- [ ] **PR Gate**: Depenemy runs on every pull request with `--fail-on error`
-- [ ] **Scheduled Scan**: Depenemy runs on a schedule against default branches to catch new advisories on existing pins
-- [ ] **Tuned Config**: A committed `.depenemy.yml` documents every ignored rule with a reason
+- [ ] **PR gate** — depenemy runs on every pull request with `--fail-on error`
+- [ ] **Scheduled scan** — depenemy runs on a schedule against default branches to catch new advisories on existing pins
+- [ ] **Tuned config** — a committed `.depenemy.yml` documents every ignored rule with a reason
 
-### 🤖 GitHub Dependabot
+### GitHub Dependabot
 
 W3OS recommends Dependabot for all teams hosting on GitHub — with an important distinction between its **alerting** and its **automatic update** features:
 
-- [ ] **Dependency Graph**: **Enabled** on all repositories
-- [ ] **Dependabot Alerts**: **Enabled** on all repositories — this is your baseline notification channel for known-vulnerable dependencies
-- [ ] **Alert Access**: Restricted to admins and the people who triage them
-- [ ] **Automatic Update PRs**: **Disabled** by default (security updates, grouped updates, and version updates) — automatic PRs pull newly-published versions on the attacker's timeline, and normalize a merge-without-reading culture around dependency changes
-- [ ] **If Version Updates Are Used**: Configure a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) period (≥ 7 days) in `dependabot.yml`, require human review on every PR, and never enable auto-merge
+- [ ] **Dependency graph enabled** on all repositories
+- [ ] **Dependabot alerts enabled** on all repositories — this is your baseline notification channel for known-vulnerable dependencies
+- [ ] **Alert access restricted** to admins and the people who triage them
+- [ ] **Automatic update PRs disabled by default** (security updates, grouped updates, and version updates) — automatic PRs pull newly-published versions on the attacker's timeline, and normalize a merge-without-reading culture around dependency changes
+- [ ] **If version updates are used** — configure a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) period (≥ 7 days) in `dependabot.yml`, require human review on every PR, and never enable auto-merge
 
 This matches the W3OS [GitHub configuration guide](<account configurations/organizations/devops-accounts/github.md>): alerts tell you *what* needs updating; the update itself should go through your deliberate, reviewed update process above.
 
-### 🔧 Ecosystem-Native Tools
+### Ecosystem-native tools
 
 Layer these alongside depenemy and Dependabot where they fit your stack:
 
-- **npm / Node.js**: `npm audit` for advisories; `ignore-scripts=true` in `.npmrc`; `npm ci` in CI; pnpm's `minimumReleaseAge` for enforced cooldown
-- **Python**: [pip-audit](https://github.com/pypa/pip-audit) for advisories; hash-pinned requirements with `pip install --require-hashes`; prefer `uv`/`poetry` lockfiles
-- **Rust**: [cargo-audit](https://github.com/rustsec/rustsec) against the RustSec database; [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) for policy enforcement; [cargo-vet](https://github.com/mozilla/cargo-vet) to require audits for new dependencies
-- **Cross-ecosystem**: [osv-scanner](https://github.com/google/osv-scanner) for OSV advisory coverage across lockfiles
+- **npm / Node.js** — `npm audit` for advisories; `ignore-scripts=true` in `.npmrc`; `npm ci` in CI; pnpm's `minimumReleaseAge` for enforced cooldown
+- **Python** — [pip-audit](https://github.com/pypa/pip-audit) for advisories; hash-pinned requirements with `pip install --require-hashes`; prefer `uv`/`poetry` lockfiles
+- **Rust** — [cargo-audit](https://github.com/rustsec/rustsec) against the RustSec database; [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) for policy enforcement; [cargo-vet](https://github.com/mozilla/cargo-vet) to require audits for new dependencies
+- **Cross-ecosystem** — [osv-scanner](https://github.com/google/osv-scanner) for OSV advisory coverage across lockfiles
 
 ---
 
 ## Ecosystem Notes for Web3 Projects
 
 **JavaScript / TypeScript frontends**
-- [ ] Frontend dependency compromise ships directly to users — apply the strictest pinning, cooldown, and review here, not the loosest
-- [ ] Use Subresource Integrity for any scripts loaded from CDNs, and avoid third-party scripts on transaction-signing pages entirely
-- [ ] Verify wallet-adjacent packages (wallet adapters, signing libraries, address utilities) with extra care — they are the most-typosquatted category in Web3
+
+- [ ] **Apply the strictest controls to frontends, not the loosest** — frontend dependency compromise ships directly to users
+- [ ] **Use Subresource Integrity** for any scripts loaded from CDNs, and avoid third-party scripts on transaction-signing pages entirely
+- [ ] **Verify wallet-adjacent packages with extra care** — wallet adapters, signing libraries, and address utilities are the most-typosquatted category in Web3
 
 **Solidity / smart contract repos**
-- [ ] Foundry: pin dependencies to exact commit hashes (git submodules or `foundry.toml` with locked tags), never floating branches like `master`
-- [ ] Hardhat and Foundry-with-npm setups inherit the full npm threat model — everything in this guide applies to your contracts repo, not just your frontend
-- [ ] Vendored/audited contract dependencies (e.g. OpenZeppelin) must be updated deliberately and re-reviewed — a dependency bump in contracts can change what you deploy on-chain
+
+- [ ] **Pin Foundry dependencies to exact commit hashes** — git submodules or `foundry.toml` with locked tags, never floating branches like `master`
+- [ ] **Treat contract repos as npm projects too** — Hardhat and Foundry-with-npm setups inherit the full npm threat model; everything in this guide applies to your contracts repo, not just your frontend
+- [ ] **Re-review vendored contract dependencies on every bump** — a dependency update in contracts (e.g. OpenZeppelin) can change what you deploy on-chain
 
 **CI/CD**
-- [ ] Dependency installation runs in CI jobs with the minimum secrets possible — build steps that run third-party code should not have access to deployment credentials or signing keys (see the [Deployments & Infrastructure Guide](deployments-infra-access-control.md))
-- [ ] Pin GitHub Actions to full commit SHAs, not tags — actions are dependencies too
-- [ ] Fork PRs must never run workflows with secret access without approval
+
+- [ ] **Install dependencies with minimum secrets** — build steps that run third-party code should not have access to deployment credentials or signing keys (see the [Secure Deployments & Infrastructure Guide](deployments-infra-access-control.md))
+- [ ] **Pin GitHub Actions to full commit SHAs**, not tags — actions are dependencies too
+- [ ] **Never let fork PRs run workflows with secret access** without approval
 
 ---
 
@@ -213,14 +216,14 @@ Layer these alongside depenemy and Dependabot where they fit your stack:
 
 When a dependency you use is reported malicious or compromised, treat it as an active incident (see the [Incident Response Readiness Guide](incident-response-readiness.md)):
 
-- [ ] **Confirm Exposure**: Check lockfiles across all repos and branches to determine whether the affected versions were ever resolved and installed — the advisory's version range vs. your pinned versions decides everything
-- [ ] **Freeze the Pipeline**: Pause deploys and CI for affected repos until the dependency is removed or pinned to a clean version
-- [ ] **Assume Execution**: If an affected version was installed anywhere, assume its code ran — on developer machines, in CI, or in production builds
-- [ ] **Rotate Exposed Secrets**: Rotate credentials available to any environment that installed the package: CI secrets, cloud credentials, npm/PyPI publish tokens, and API keys. Treat any hot wallet keys that touched an affected machine as compromised and migrate funds
-- [ ] **Audit Published Artifacts**: Check whether affected versions were bundled into anything you shipped — frontend builds, published packages, or container images — and pull/rebuild them
-- [ ] **Rebuild Environments**: Wipe and rebuild developer environments and CI runners that installed affected versions rather than trying to clean them
-- [ ] **Communicate**: If users may have interacted with a compromised frontend, notify them immediately through verified channels with concrete guidance (revoke approvals, migrate funds)
-- [ ] **Post-Incident**: Record how the dependency got in and which lifecycle control failed, then fix that control — cooldown, review depth, pinning, or monitoring
+- [ ] **Confirm exposure** — check lockfiles across all repos and branches to determine whether the affected versions were ever resolved and installed; the advisory's version range vs. your pinned versions decides everything
+- [ ] **Freeze the pipeline** — pause deploys and CI for affected repos until the dependency is removed or pinned to a clean version
+- [ ] **Assume execution** — if an affected version was installed anywhere, assume its code ran: on developer machines, in CI, or in production builds
+- [ ] **Rotate exposed secrets** — rotate credentials available to any environment that installed the package: CI secrets, cloud credentials, npm/PyPI publish tokens, and API keys. Treat any hot wallet keys that touched an affected machine as compromised and migrate funds
+- [ ] **Audit published artifacts** — check whether affected versions were bundled into anything you shipped (frontend builds, published packages, container images) and pull/rebuild them
+- [ ] **Rebuild environments** — wipe and rebuild developer environments and CI runners that installed affected versions rather than trying to clean them
+- [ ] **Communicate** — if users may have interacted with a compromised frontend, notify them immediately through verified channels with concrete guidance (revoke approvals, migrate funds)
+- [ ] **Close the loop** — record how the dependency got in and which lifecycle control failed, then fix that control: cooldown, review depth, pinning, or monitoring
 
 ---
 

--- a/guides/supply-chain-dependency-security.md
+++ b/guides/supply-chain-dependency-security.md
@@ -1,0 +1,235 @@
+<!--
+id: supply-chain-dependency-security-organization-guide
+type: GUIDE
+scope: ORGANIZATION
+-->
+
+<div align="center">
+  <h1>Supply Chain & Dependency Security Guide</h1>
+  <p><em>Managing third-party code risk across the full dependency lifecycle</em></p>
+</div>
+
+---
+
+## Overview
+
+A modern Web3 project is mostly code your team did not write. A typical frontend or tooling repo pulls in hundreds of transitive dependencies, each one authored, published, and updated by someone outside your organization. Every one of those packages is code that runs on developer machines, inside CI runners holding deployment secrets, and in the frontends your users trust with their wallets.
+
+Attackers know this. Web3 teams are disproportionately targeted with malicious packages because the payoff is immediate and irreversible: a single compromised dependency can exfiltrate private keys and seed phrases, swap recipient addresses in a frontend, or steal cloud and signing credentials from CI. Supply chain attacks bypass your perimeter entirely — you invite the code in yourself.
+
+This guide covers how to vet, pin, update, monitor, and respond to dependencies as a managed attack surface, and the tooling W3OS recommends for automating it.
+
+---
+
+## Security Risks
+
+- **🎣 Malicious Packages by Design**
+  - Typosquatting: names one character away from popular packages (`ethes`, `web3.js` vs `web3js`)
+  - Dependency confusion: public packages published under your internal/private package names, winning resolution over the real ones
+  - Starter kits, "airdrop tools," and job-interview "take-home projects" seeded with credential stealers
+
+- **📦 Compromised Legitimate Packages**
+  - Maintainer account takeover via phishing or credential stuffing, followed by a malicious release of a trusted package
+  - Ownership transfer to a "helpful new maintainer" who later ships a payload
+  - Abandoned or archived projects silently adopted by attackers
+
+- **⚙️ Install-Time Code Execution**
+  - npm `preinstall`/`postinstall` scripts run arbitrary code the moment you (or CI) run `npm install` — before you ever import the package
+  - Build-time code in setup scripts and build plugins with the same effect in other ecosystems
+
+- **🔄 Update-Channel Attacks**
+  - Loose version ranges (`^`, `~`, `>=`, `*`) automatically pull the next published version — the exact window a hijacked release exploits
+  - Lockfile tampering in pull requests, hiding a swapped package or resolved URL inside thousands of lockfile diff lines
+  - Auto-merged update PRs shipping a compromised version to production with no human review
+
+- **🏗️ Build, CI, and User Exposure**
+  - Dependencies execute inside CI with access to workflow secrets, signing keys, and deploy credentials
+  - Frontend dependencies ship directly to users' browsers — a compromised UI package becomes a wallet drainer
+  - Compromised developer machines (see the [Developer Security Guide](developer-security-best-practices.md)) become a path to publishing malicious versions of *your own* packages
+
+---
+
+## The Dependency Lifecycle
+
+Treat every dependency as a vendor relationship with distinct decisions at each stage: **intake → pinning → updating → monitoring → removal**.
+
+### 🔍 Intake: Vetting New Dependencies
+
+Every new dependency is a permanent expansion of your attack surface. Vet before the first install:
+
+- [ ] **Necessity First**: Prefer the standard library, existing dependencies, or a small amount of first-party code over adding a new package for trivial functionality
+- [ ] **Package Age**: Require versions at least 6 months old with balanced usage metrics — brand-new packages and brand-new versions carry the highest risk
+- [ ] **Health Signals**: Check weekly downloads, contributor count, maintenance activity, and whether a linked source repository exists and is not archived
+- [ ] **Name Verification**: Compare the package name character-by-character against official documentation in a monospace font; never install a name from a chat message, search result, or LLM output without verifying it
+- [ ] **Install Scripts**: Check for `preinstall`/`postinstall` scripts (`npm pkg get scripts` on the tarball, or a depenemy scan) and treat their presence as requiring justification
+- [ ] **Source Review**: Skim the actual published artifact (not just the GitHub repo — they can differ) for obfuscated code, network calls, or environment variable access that doesn't match the package's purpose
+- [ ] **Scan Before Adding**: Run [depenemy](https://github.com/W3OSC/depenemy) against the change introducing the dependency so reputation and supply chain checks run before merge
+- [ ] **Sandbox First Contact**: Perform first installs and evaluation of unfamiliar packages in an isolated environment, never on a machine with wallet or production access
+
+### 📌 Pinning & Lockfiles
+
+Make every install reproducible and every change to third-party code visible in review:
+
+- [ ] **Exact Pins**: Pin direct dependencies to exact versions — no `^`, `~`, `>=`, or `*` ranges in manifests
+- [ ] **Lockfiles Committed**: Commit `package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`, `Cargo.lock`, `uv.lock`/`poetry.lock` (or hash-pinned requirements) to version control for every project, including internal tools
+- [ ] **Lockfile-Only Installs in CI**: Use `npm ci` (not `npm install`), `pip install --require-hashes`, `cargo build --locked`, etc., so CI can never resolve versions the lockfile doesn't contain
+- [ ] **Disable Install Scripts by Default**: Set `ignore-scripts=true` in `.npmrc` (npm/yarn/pnpm) and explicitly allowlist the few packages that genuinely need build scripts (pnpm supports this natively)
+- [ ] **Review Lockfile Diffs**: Treat lockfile changes as code changes; reviewers must check that resolved packages, versions, and registry URLs match the intended update
+- [ ] **Pin Transitives When Needed**: Use `overrides` (npm), `resolutions` (yarn), or equivalent to force known-good versions of vulnerable or suspicious transitive dependencies
+
+### 🔄 Updating Deliberately
+
+Staying outdated is a risk; updating blindly is a bigger one. Updates should be **deliberate, delayed, and reviewed**:
+
+- [ ] **Release Cooldown**: Never adopt a version less than 7 days old — most malicious releases are detected and pulled within days of publication. Enforce this with a configured cooldown policy (Dependabot `cooldown`, Renovate `minimumReleaseAge`, or pnpm `minimumReleaseAge`) rather than convention
+- [ ] **Human Review Required**: Every dependency update lands via a pull request reviewed by a human — never auto-merge dependency updates, including "patch-only" ones
+- [ ] **Read Before Merging**: For security-sensitive or widely-used packages, review the changelog and the actual diff between published versions before approving
+- [ ] **Prioritize by Exposure**: Fast-track updates that fix vulnerabilities exploitable in your usage; batch routine version bumps on a regular cadence
+- [ ] **Rebuild and Test in Isolation**: Run updated dependencies through CI and isolated environments before they reach machines with production or signing access
+
+### 📡 Continuous Monitoring
+
+New vulnerabilities and newly-flagged malicious packages affect dependencies you already pinned:
+
+- [ ] **Dependabot Alerts**: Enable the dependency graph and Dependabot alerts on all repositories (see the [GitHub configuration guide](<account configurations/organizations/devops-accounts/github.md>)) so known-vulnerable versions surface automatically
+- [ ] **Scheduled Scans**: Run depenemy on a schedule (not just on PRs) so newly-published advisories and reputation changes against existing pins are caught
+- [ ] **Alert Routing**: Route dependency alerts to a channel the team actually triages, with an owner and an SLA — an ignored alert stream is equivalent to no alerts
+- [ ] **Dependency Inventory**: Maintain visibility into what you depend on across all repos (GitHub dependency graph, or SBOM generation for release artifacts) so "are we affected?" takes minutes, not days
+
+### 🗑️ Removal & Pruning
+
+- [ ] **Regular Pruning**: Periodically remove unused dependencies (`depcheck`, `cargo machete`, etc.) — every removed package is attack surface gone
+- [ ] **Replace the Abandoned**: Migrate away from deprecated, archived, or single-maintainer packages in critical paths before they become someone else's takeover target
+- [ ] **Full Removal**: When removing a package, confirm it also leaves the lockfile and that no scripts or CI steps still reference it
+
+---
+
+## Recommended Tooling
+
+### 🛡️ Depenemy
+
+[Depenemy](https://github.com/W3OSC/depenemy) is W3OSC's open-source dependency scanner, built specifically around the supply chain threat model described in this guide. It scans npm/Node.js, Python, Rust, and Solidity (Foundry/Hardhat) projects for three categories of findings:
+
+- **Behavioral risks** — unpinned versions and loose ranges, lagging versions, missing lockfiles, missing release-cooldown policies
+- **Reputation signals** — young author accounts, new packages/versions, low download counts, stale or deprecated packages, known-vulnerable versions, suspected typosquatting
+- **Supply chain risks** — install scripts, missing or archived source repositories, dependency confusion exposure, packages recorded as malicious in OSV
+
+**Setup:**
+
+```bash
+pip install depenemy
+
+# Scan a project
+depenemy scan .
+
+# Gate CI on findings
+depenemy scan . --fail-on error
+
+# List all checks
+depenemy rules
+```
+
+**CI integration** — surface findings in the repository Security tab on every push and pull request:
+
+```yaml
+# .github/workflows/depenemy.yml
+name: Depenemy scan
+on: [push, pull_request]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: W3OSC/depenemy-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on: error
+```
+
+**Pre-commit hook** — block high-severity findings before they're committed:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/W3OSC/depenemy
+    rev: v0.1.4
+    hooks:
+      - id: depenemy
+```
+
+Thresholds, per-rule severities, and ignores are configured in a `.depenemy.yml` at the repository root, so teams can tune checks (e.g. for internal packages) without disabling scanning.
+
+- [ ] **PR Gate**: Depenemy runs on every pull request with `--fail-on error`
+- [ ] **Scheduled Scan**: Depenemy runs on a schedule against default branches to catch new advisories on existing pins
+- [ ] **Tuned Config**: A committed `.depenemy.yml` documents every ignored rule with a reason
+
+### 🤖 GitHub Dependabot
+
+W3OS recommends Dependabot for all teams hosting on GitHub — with an important distinction between its **alerting** and its **automatic update** features:
+
+- [ ] **Dependency Graph**: **Enabled** on all repositories
+- [ ] **Dependabot Alerts**: **Enabled** on all repositories — this is your baseline notification channel for known-vulnerable dependencies
+- [ ] **Alert Access**: Restricted to admins and the people who triage them
+- [ ] **Automatic Update PRs**: **Disabled** by default (security updates, grouped updates, and version updates) — automatic PRs pull newly-published versions on the attacker's timeline, and normalize a merge-without-reading culture around dependency changes
+- [ ] **If Version Updates Are Used**: Configure a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) period (≥ 7 days) in `dependabot.yml`, require human review on every PR, and never enable auto-merge
+
+This matches the W3OS [GitHub configuration guide](<account configurations/organizations/devops-accounts/github.md>): alerts tell you *what* needs updating; the update itself should go through your deliberate, reviewed update process above.
+
+### 🔧 Ecosystem-Native Tools
+
+Layer these alongside depenemy and Dependabot where they fit your stack:
+
+- **npm / Node.js**: `npm audit` for advisories; `ignore-scripts=true` in `.npmrc`; `npm ci` in CI; pnpm's `minimumReleaseAge` for enforced cooldown
+- **Python**: [pip-audit](https://github.com/pypa/pip-audit) for advisories; hash-pinned requirements with `pip install --require-hashes`; prefer `uv`/`poetry` lockfiles
+- **Rust**: [cargo-audit](https://github.com/rustsec/rustsec) against the RustSec database; [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) for policy enforcement; [cargo-vet](https://github.com/mozilla/cargo-vet) to require audits for new dependencies
+- **Cross-ecosystem**: [osv-scanner](https://github.com/google/osv-scanner) for OSV advisory coverage across lockfiles
+
+---
+
+## Ecosystem Notes for Web3 Projects
+
+**JavaScript / TypeScript frontends**
+- [ ] Frontend dependency compromise ships directly to users — apply the strictest pinning, cooldown, and review here, not the loosest
+- [ ] Use Subresource Integrity for any scripts loaded from CDNs, and avoid third-party scripts on transaction-signing pages entirely
+- [ ] Verify wallet-adjacent packages (wallet adapters, signing libraries, address utilities) with extra care — they are the most-typosquatted category in Web3
+
+**Solidity / smart contract repos**
+- [ ] Foundry: pin dependencies to exact commit hashes (git submodules or `foundry.toml` with locked tags), never floating branches like `master`
+- [ ] Hardhat and Foundry-with-npm setups inherit the full npm threat model — everything in this guide applies to your contracts repo, not just your frontend
+- [ ] Vendored/audited contract dependencies (e.g. OpenZeppelin) must be updated deliberately and re-reviewed — a dependency bump in contracts can change what you deploy on-chain
+
+**CI/CD**
+- [ ] Dependency installation runs in CI jobs with the minimum secrets possible — build steps that run third-party code should not have access to deployment credentials or signing keys (see the [Deployments & Infrastructure Guide](deployments-infra-access-control.md))
+- [ ] Pin GitHub Actions to full commit SHAs, not tags — actions are dependencies too
+- [ ] Fork PRs must never run workflows with secret access without approval
+
+---
+
+## Responding to a Compromised Dependency
+
+When a dependency you use is reported malicious or compromised, treat it as an active incident (see the [Incident Response Readiness Guide](incident-response-readiness.md)):
+
+- [ ] **Confirm Exposure**: Check lockfiles across all repos and branches to determine whether the affected versions were ever resolved and installed — the advisory's version range vs. your pinned versions decides everything
+- [ ] **Freeze the Pipeline**: Pause deploys and CI for affected repos until the dependency is removed or pinned to a clean version
+- [ ] **Assume Execution**: If an affected version was installed anywhere, assume its code ran — on developer machines, in CI, or in production builds
+- [ ] **Rotate Exposed Secrets**: Rotate credentials available to any environment that installed the package: CI secrets, cloud credentials, npm/PyPI publish tokens, and API keys. Treat any hot wallet keys that touched an affected machine as compromised and migrate funds
+- [ ] **Audit Published Artifacts**: Check whether affected versions were bundled into anything you shipped — frontend builds, published packages, or container images — and pull/rebuild them
+- [ ] **Rebuild Environments**: Wipe and rebuild developer environments and CI runners that installed affected versions rather than trying to clean them
+- [ ] **Communicate**: If users may have interacted with a compromised frontend, notify them immediately through verified channels with concrete guidance (revoke approvals, migrate funds)
+- [ ] **Post-Incident**: Record how the dependency got in and which lifecycle control failed, then fix that control — cooldown, review depth, pinning, or monitoring
+
+---
+
+## Related W3OS Requirements
+
+This guide implements the supply chain controls from [Domain 4: DevOps & Infrastructure](../requirements/04-devops-infrastructure.md):
+
+- **SP-DI-005** — Package Verification and Integrity
+- **SP-DI-006** — Typosquatting Detection and Prevention
+- **SP-DI-007** — Dependency Management and Scanning
+
+addressing risks R-DI-003 (Supply Chain Attacks Through Dependencies), R-DI-010 (Compromised Software Dependencies and Packages), and R-DI-011 (Typosquatting and Package Name Confusion Attacks).


### PR DESCRIPTION
## What this does

Two related pieces of work, folded into one PR so the whole `guides/` directory lands in a single consistent style:

### 1. New: Supply Chain & Dependency Security guide

Covers the full dependency lifecycle (intake, pinning, updating, monitoring, removal), recommended tooling (depenemy, Dependabot, ecosystem-native scanners), Web3-specific ecosystem notes, and incident response for compromised dependencies. Cross-linked from the Developer Security guide and mapped to requirements SP-DI-005/006/007.

### 2. Quality pass on the seven existing general guides

A full editorial pass over every guide that is not an account-configuration guide, bringing them to the bar set by the cloud-platform tightening in #23. Net −150 lines across those seven files with no substantive content removed.

**Consistent structure** — every guide (including the new supply-chain one) now follows the same skeleton: metadata comment → centered title + tagline → Overview → `##` sections with `---` separators, sentence-case `###` subsections, short prose lead-ins instead of 💡 bold walls, checklist items in the `**bold action** — rationale` pattern, no decorative emoji, and fixed heading hierarchy (the Personal Security Checklist previously used `#` for body sections).

**Redundancy removed via canonical homes:**
- SIM swap carrier steps (AT&T/T-Mobile/Verizon/Fi) moved into the Authentication & MFA guide; the Personal Security Checklist links to them
- Device/network hardening baseline (FDE, DNS, VPN, Little Snitch/LuLu/GlassWire/BlockBlock) is canonical in the Personal Security Checklist; the Developer Security guide points there and keeps only dev-specific isolation (trust levels, containers, browser separation, OS controls, secrets)
- Auth guide's "Common Pitfalls" section deleted — it repeated its own checklist verbatim
- Deployments ↔ Incident Response guides cross-link instead of restating break-glass/monitoring material

**Fixes along the way:**
- Semantic: "write-only" logs → append-only; resolved an SMS-recovery contradiction between the auth guide and the checklist; fixed a seed-shard item that contradicted its own "never digital" rule
- Typos: TOPT→TOTP (×2), "Do no allow", "include to security fixes", product spellings (LuLu, GlassWire, SentinelOne)
- DNS guide's broken hard-wrapped lines and trailing whitespace (terminal-paste artifacts) repaired
- Multisig guide retitled "Multi-Sig Wallet Security Guide" (file name and metadata id unchanged)

`node scripts/validate.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)